### PR TITLE
Start using typed values in overlay module

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,8 @@
       2,
       {
         "ignore": [
-          "^std$"
+          "^std$",
+          "/?(api|shapes)$",
         ]
       }
     ],

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jobs:
       script: npm run lint
 
     - name: unit tests
-      script: npm test
+      script: make test
 
     - stage: Deploy
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,13 @@ cache: npm
 env:
   global:
     - GOVERSION=1.11.2
+    - GOPATH=
+    - GOROOT=
+    - PATH=~/go-${GOVERSION}/bin:~/go/bin:$PATH
+
+before_install:
+    - (cd ~ && curl -fsSLO https://dl.google.com/go/go${GOVERSION}.linux-amd64.tar.gz)
+    - mkdir ~/go-${GOVERSION} && tar xf ~/go${GOVERSION}.linux-amd64.tar.gz -C ~/go-${GOVERSION} --strip-components 1
 
 jobs:
   include:
@@ -18,13 +25,7 @@ jobs:
 
     - stage: Deploy
       script:
-        # go
-        - (cd ~ && curl -fsSLO https://dl.google.com/go/go${GOVERSION}.linux-amd64.tar.gz)
-        - mkdir ~/go-${GOVERSION} && tar xf ~/go${GOVERSION}.linux-amd64.tar.gz -C ~/go-${GOVERSION} --strip-components 1
-        - unset GOPATH GOROOT
-        - export PATH=~/go-${GOVERSION}/bin:~/go/bin:$PATH
-
         # build and publish
-        - make gen dist
+        - make dist
         - cd dist && npm publish
       if: tag IS present

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,10 @@ all: gen
 gen:
 	go run ./cmd/apigen/ cmd/apigen/specs/swagger-v1.13.0.json cmd/apigen/templates ./src/
 
-dist: src/api.ts
+src/api.ts: gen
+src/shapes.ts: gen
+
+dist: src/api.ts src/shapes.ts
 	npx tsc
 	npx tsc -d --emitDeclarationOnly --allowJs false
 	cp README.md LICENSE package.json .npmrc $@
@@ -14,3 +17,5 @@ clean:
 	rm -rf dist
 	rm -f src/api.ts src/shapes.ts
 
+test: dist
+	npm test

--- a/Makefile
+++ b/Makefile
@@ -17,5 +17,5 @@ clean:
 	rm -rf dist
 	rm -f src/api.ts src/shapes.ts
 
-test: dist
+test: gen
 	npm test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dist clean-dist gen
+.PHONY: dist clean-dist gen test
 
 all: gen
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1443,6 +1443,15 @@
         "electron-to-chromium": "^1.3.47"
       }
     },
+    "bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "requires": {
+        "fast-json-stable-stringify": "2.x"
+      }
+    },
     "bser": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
@@ -2547,14 +2556,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
@@ -2569,20 +2576,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2699,8 +2703,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2712,7 +2715,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
@@ -2727,7 +2729,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "1.1.11"
           }
@@ -2735,14 +2736,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "5.1.1",
             "yallist": "3.0.2"
@@ -2761,7 +2760,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2842,8 +2840,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2855,7 +2852,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1.0.2"
           }
@@ -2977,7 +2973,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
@@ -4382,6 +4377,12 @@
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
+    },
+    "make-error": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+      "dev": true
     },
     "makeerror": {
       "version": "1.0.11",
@@ -6387,6 +6388,49 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
+    },
+    "ts-jest": {
+      "version": "23.10.5",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-23.10.5.tgz",
+      "integrity": "sha512-MRCs9qnGoyKgFc8adDEntAOP64fWK1vZKnOYU1o2HxaqjdJvGqmkLCPCnVq1/If4zkUmEjKPnCiUisTrlX2p2A==",
+      "dev": true,
+      "requires": {
+        "bs-logger": "0.x",
+        "buffer-from": "1.x",
+        "fast-json-stable-stringify": "2.x",
+        "json5": "2.x",
+        "make-error": "1.x",
+        "mkdirp": "0.x",
+        "resolve": "1.x",
+        "semver": "^5.5",
+        "yargs-parser": "10.x"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+          "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
+      }
     },
     "tslib": {
       "version": "1.9.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.14.0",
     "jest": "^23.6.0",
+    "ts-jest": "^23.10.5",
     "typescript": "^3.2.2"
   },
   "homepage": "https://github.com/jkcfg/kubernetes#readme",
@@ -35,14 +36,14 @@
     "test": "jest"
   },
   "jest": {
+    "preset": "ts-jest/presets/js-with-babel",
     "testMatch": [
       "<rootDir>/tests/*.test.js"
     ],
-    "transform": {
-      ".*": "<rootDir>/node_modules/babel-jest"
-    },
     "transformIgnorePatterns": [],
-    "moduleDirectories": ["<rootDir>/node_modules"]
+    "moduleDirectories": [
+      "<rootDir>/node_modules"
+    ]
   },
   "version": "0.1.0"
 }

--- a/src/overlay/generators.js
+++ b/src/overlay/generators.js
@@ -1,6 +1,6 @@
 import { dataFromFiles } from './data';
 import { basename } from '../path';
-import { ConfigMap, Secret } from '../kubernetes';
+import { core } from '../api';
 import { encode as base64encode, ascii2bytes } from '../base64';
 
 const generateConfigMap = readStr => async function generate(config) {
@@ -20,7 +20,7 @@ const generateConfigMap = readStr => async function generate(config) {
     d.forEach((v, k) => {
       data[basename(k)] = v;
     });
-    return new ConfigMap(undefined, name, data);
+    return new core.v1.ConfigMap(name, { data });
   });
 };
 
@@ -64,7 +64,7 @@ const generateSecret = readBytes => async function generate(config) {
     d.forEach((v, k) => {
       data[basename(k)] = base64encode(v);
     });
-    return new Secret(undefined, name, data);
+    return new core.v1.Secret(name, { data });
   });
 };
 

--- a/tests/generators.test.js
+++ b/tests/generators.test.js
@@ -1,5 +1,5 @@
-import { generateConfigMap, generateSecret } from '../src/overlay/generators';
-import { ConfigMap, Secret } from '../src/kubernetes';
+import { generateConfigMap, generateSecret } from '../dist/overlay/generators';
+import { core } from '../dist/api';
 import { fs } from './mock';
 
 test('empty configmap', () => {
@@ -8,7 +8,7 @@ test('empty configmap', () => {
     throw new Error('unexpected read of ${f}');
   });
   return gen({name: 'foo-conf'}).then((v) => {
-    expect(v).toEqual(new ConfigMap(undefined, 'foo-conf', {}));
+    expect(v).toEqual(new core.v1.ConfigMap('foo-conf', { data: {} }));
   })
 });
 
@@ -25,9 +25,11 @@ test('files and literals', () => {
   };
   expect.assertions(1);
   return gen(conf).then((v) => {
-    expect(v).toEqual(new ConfigMap(undefined, 'foo-conf', {
-      'foo.yaml': 'foo: bar',
-      'some.property': 'some.value',
+    expect(v).toEqual(new core.v1.ConfigMap('foo-conf', {
+      data: {
+        'foo.yaml': 'foo: bar',
+        'some.property': 'some.value',
+      }
     }));
   });
 });
@@ -49,9 +51,11 @@ test('secret from literal', () => {
 
   expect.assertions(1);
   return gen(conf).then((v) => {
-    expect(v).toEqual(new Secret(undefined, 'foo-secret', {
-      'foo.bin': foobarEncoded,
-      'foo.literal': foobarEncoded,
+    expect(v).toEqual(new core.v1.Secret('foo-secret', {
+      data: {
+        'foo.bin': foobarEncoded,
+        'foo.literal': foobarEncoded,
+      }
     }));
   });
 });

--- a/tests/generators.test.js
+++ b/tests/generators.test.js
@@ -1,5 +1,5 @@
-import { generateConfigMap, generateSecret } from '../dist/overlay/generators';
-import { core } from '../dist/api';
+import { generateConfigMap, generateSecret } from '../src/overlay/generators';
+import { core } from '../src/api';
 import { fs } from './mock';
 
 test('empty configmap', () => {

--- a/tests/overlay.test.js
+++ b/tests/overlay.test.js
@@ -1,6 +1,6 @@
-import overlay from '../dist/overlay';
+import overlay from '../src/overlay';
 import { fs, Encoding } from './mock';
-import { core } from '../dist/api';
+import { core } from '../src/api';
 
 test('trivial overlay: no bases, resources, patches', () => {
   const { read } = fs({}, {});

--- a/tests/overlay.test.js
+++ b/tests/overlay.test.js
@@ -1,6 +1,6 @@
-import overlay from '../src/overlay';
+import overlay from '../dist/overlay';
 import { fs, Encoding } from './mock';
-import { ConfigMap, Secret } from '../src/kubernetes';
+import { core } from '../dist/api';
 
 test('trivial overlay: no bases, resources, patches', () => {
   const { read } = fs({}, {});
@@ -140,12 +140,16 @@ test('generate resources', () => {
     './bar': { string: 'foo' },
   };
 
-  const configmap = new ConfigMap(undefined, 'foobar', {
-    'foo': 'bar',
-    'bar': 'foo',
+  const configmap = new core.v1.ConfigMap('foobar', {
+    data: {
+      'foo': 'bar',
+      'bar': 'foo',
+    }
   });
-  const secret = new Secret(undefined, 'ssshh', {
-    'foo': 'Zm9vYmFy',
+  const secret = new core.v1.Secret('ssshh', {
+    data: {
+      'foo': 'Zm9vYmFy',
+    }
   });
 
   const o = overlay(fs({}, files));

--- a/tests/transforms.test.js
+++ b/tests/transforms.test.js
@@ -37,6 +37,5 @@ test('patch something', () => {
   // the spec, rather than assigning into it.
   const expected = {...resource};
   expected.spec = {...resource.spec, replicas: 6};
-  
   expect(p(resource)).toEqual(expected);
 });


### PR DESCRIPTION
First step in typification: use the classes generated (via TypeScript)
from the Kubernetes API spec.

~This needs test code to refer to dist/, since that's where the
generated code ends up.~ Module code can just use relative paths as
before.

EDIT: Test code can refer to `../src/...`, after introducing ts-jest which will compile the TypeScript modules while tests run. So in the whole, relatively little changes, other than using the classes from generated code, and generating files before running tests.

This is a reasonable basis on which to proceed, I think -- we can now use either TypeScript or JavaScript, and it'll work (with the minor caveat that eslint may need to be told about unresolvable imports). At some point we should probably introduce tslint, though).