### PR TITLE
Tidy away some warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,10 +37,18 @@
   },
   "jest": {
     "preset": "ts-jest/presets/js-with-babel",
+    "globals": {
+      "ts-jest": {
+        "diagnostics": {
+        "ignoreCodes": [151001]
+        }
+      }
+    },
     "testMatch": [
       "<rootDir>/tests/*.test.js"
     ],
-    "transformIgnorePatterns": [],
+    "transformIgnorePatterns": ["<rootDir>/dist/"],
+    "modulePathIgnorePatterns": ["<rootDir>/dist/"],
     "moduleDirectories": [
       "<rootDir>/node_modules"
     ]


### PR DESCRIPTION
 - stop Jest from complaining about a duplicate package.json by
   telling it to ignore <rootDir>dist/
 - suppress the TypeScript advisory re imports (which don't appear to
   be broken, so ..)