### PR TITLE
Examples: A Helm chart-alike

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,7 @@
       {
         "ignore": [
           "^std$",
+          "^@jkcfg/std$",
           "/?(api|shapes)$",
         ]
       }

--- a/examples/chart/README.md
+++ b/examples/chart/README.md
@@ -1,0 +1,2 @@
+# Analogue to a Helm chart
+

--- a/examples/chart/README.md
+++ b/examples/chart/README.md
@@ -1,2 +1,79 @@
 # Analogue to a Helm chart
 
+This examples shows a Helm chart analogue for `jk`. The aim is to have
+a template to which you can supply values upon
+instantiation. Secondarily, the "chart" can be published, and reused
+in another configuration. It's not a goal here to reproduce the
+runtime bits of Helm -- that is, keeping track of which charts have
+been released to the cluster.
+
+## To run the example
+
+(in this directory)
+
+```js
+npm install '@jkcfg/kubernetes'
+# or: make -C ../.. dist && npm install ../../dist
+
+# run the chart with defaults
+jk run ./index.js
+
+# run the chart with some value parameter overrides
+jk run ./index.js -p values.app=goodbye -f ./values.json
+```
+
+## Explanation
+
+A Helm chart is a directory of files, including:
+
+ - `Chart.yaml`, which contains metadata used for packaging;
+ - `values.yaml`, which enumerates the parameters to the chart,
+   including default values;
+ - files in `templates/`, which are textual templates for the
+   resources to be created when instantiating the chart.
+
+To instantiate a chart, the Helm tooling gathers together the values
+it is called with, fills in the defaults, then runs those through the
+template (and sends them off to be applied to the cluster).
+
+The `chart(...)` library procedure used here does the same work. It
+takes a "template" function that generates resources as JavaScript
+values, given the instantiation values; it gathers the values given on
+the command line, fills in the defaults, and runs the template
+function to generate the resources, which it prints to stdout as YAML
+docs.
+
+Taking these bits one by one ..
+
+**Generating resources**
+
+The template function (in `resources.js`) is in large part an object
+literal, with a sprinkling of variable references and interpolated
+strings using the values passed to it. This may seem like a cheat,
+since Helm's templating involves a bunch of files, with special syntax
+(`gotpl`) for control flow and injecting values. Or, you could
+consider it as an indication of how much simpler things are when you
+can just write a program!
+
+If you did prefer to have separate files, you could put each resource
+definition (as a function) in its own file as a module, and import
+them all to instantiate them.
+
+**Collecting values**
+
+The `chart(...)` procedure uses the parameter-passing mechanism of
+`jk` to obtain values from the command-line or from files. To keep
+those separate from parameters intended for other purposes, it assumes
+the `values` prefix (arbitrarily, and because it's the prefix used
+with Helm charts).
+
+Since `jk` merges the parameters for us, there's little work to do
+other than merging the supplied values with the defaults as given in
+code. The defaults could also be loaded from a file; `chart` copes
+with getting a promise of defaults.
+
+**Printing the result**
+
+The chart procedure chooses how to print each resource depending on
+its representation -- either an object (as produced by resources.js),
+or a string (as a templating library would yield).

--- a/examples/chart/index.js
+++ b/examples/chart/index.js
@@ -3,6 +3,8 @@ import std from '@jkcfg/std';
 
 import resources from './resources';
 
+const readJSON = f => std.read(f, std.Encoding.JSON);
+
 const defaults = {
   name: 'helloworld',
   app: 'hello',

--- a/examples/chart/index.js
+++ b/examples/chart/index.js
@@ -1,0 +1,15 @@
+import { chart } from '@jkcfg/kubernetes/chart';
+import std from '@jkcfg/std';
+
+import resources from './resources';
+
+const defaults = {
+  name: 'helloworld',
+  app: 'hello',
+  image: {
+    repository: 'weaveworks/helloworld',
+    tag: 'v1'
+  }
+};
+
+chart(resources, defaults, std.param);

--- a/examples/chart/index.js
+++ b/examples/chart/index.js
@@ -3,8 +3,6 @@ import std from '@jkcfg/std';
 
 import resources from './resources';
 
-const readJSON = f => std.read(f, std.Encoding.JSON);
-
 const defaults = {
   name: 'helloworld',
   app: 'hello',

--- a/examples/chart/resources.js
+++ b/examples/chart/resources.js
@@ -1,0 +1,20 @@
+import { apps } from '@jkcfg/kubernetes/api';
+
+function resources(Values) {
+  return [new apps.v1.Deployment(Values.name, {
+    spec: {
+      template: {
+        labels: {app: Values.app },
+        spec: {
+          containers: {
+            'hello': {
+              image: `${Values.image.repository}:${Values.image.tag}`
+            }
+          }
+        }
+      }
+    }
+  })];
+}
+
+export default resources;

--- a/examples/chart/values.json
+++ b/examples/chart/values.json
@@ -1,6 +1,8 @@
 {
   "values": {
     "app": "olleh",
-    "tag": "v2"
+    "image": {
+      "tag": "v2"
+    }
   }
 }

--- a/examples/chart/values.json
+++ b/examples/chart/values.json
@@ -1,0 +1,6 @@
+{
+  "values": {
+    "app": "olleh",
+    "tag": "v2"
+  }
+}

--- a/examples/chart/values.yaml
+++ b/examples/chart/values.yaml
@@ -1,3 +1,0 @@
-app: olleh
-image:
-  tag: v2

--- a/examples/chart/values.yaml
+++ b/examples/chart/values.yaml
@@ -1,0 +1,3 @@
+app: olleh
+image:
+  tag: v2

--- a/src/chart/index.js
+++ b/src/chart/index.js
@@ -2,15 +2,15 @@ import std from '@jkcfg/std';
 import { writeStream } from '../write';
 import { values } from './values';
 
-const readValues = f => std.read(f, std.Encoding.JSON);
 const writeString = s => std.write(s, '');
 const writeYAML = s => std.write(s, '', { format: std.Format.YAML });
 const output = writeStream(writeString, writeYAML);
 
 function chart(resourcesFn, defaults, param) {
-  const vals = values(param, readValues);
-  const resources = vals(defaults).then(resourcesFn);
-  resources.then(output);
+  const vals = values(param);
+  const resources = resourcesFn(vals(defaults));
+  // lift a value into a Promise if necessary
+  Promise.resolve(resources).then(output);
 }
 
 export { chart };

--- a/src/chart/index.js
+++ b/src/chart/index.js
@@ -2,15 +2,26 @@ import std from '@jkcfg/std';
 import { writeStream } from '../write';
 import { values } from './values';
 
-const writeString = s => std.write(s, '');
-const writeYAML = s => std.write(s, '', { format: std.Format.YAML });
-const output = writeStream(writeString, writeYAML);
+const printString = s => std.write(s, '');
+const printYAML = s => std.write(s, '', { format: std.Format.YAML });
+
+function printValue(val) {
+  switch (typeof val) {
+  case 'string':
+    return printString(val);
+  case 'object':
+  default:
+    return printYAML(val);
+  }
+}
+
+const output = writeStream(printString, printValue);
 
 function chart(resourcesFn, defaults, param) {
-  const vals = values(param);
-  const resources = resourcesFn(vals(defaults));
-  // lift a value into a Promise if necessary
-  Promise.resolve(resources).then(output);
+  // lift defaults into Promise, since it may or may not be one
+  const vals = Promise.resolve(defaults).then(values(param));
+  const resources = vals.then(resourcesFn);
+  resources.then(output);
 }
 
 export { chart };

--- a/src/chart/index.js
+++ b/src/chart/index.js
@@ -1,0 +1,10 @@
+import std from '@jkcfg/std';
+import { writeResources } from '../write';
+
+function chart(resourcesFn, defaults, param) {
+  const values = defaults;
+  const resources = Promise.resolve(resourcesFn(values));
+  resources.then(writeResources(std.write));
+}
+
+export { chart };

--- a/src/chart/index.js
+++ b/src/chart/index.js
@@ -1,10 +1,16 @@
 import std from '@jkcfg/std';
-import { writeResources } from '../write';
+import { writeStream } from '../write';
+import { values } from './values';
+
+const readValues = f => std.read(f, std.Encoding.JSON);
+const writeString = s => std.write(s, '');
+const writeYAML = s => std.write(s, '', { format: std.Format.YAML });
+const output = writeStream(writeString, writeYAML);
 
 function chart(resourcesFn, defaults, param) {
-  const values = defaults;
-  const resources = Promise.resolve(resourcesFn(values));
-  resources.then(writeResources(std.write));
+  const vals = values(param, readValues);
+  const resources = vals(defaults).then(resourcesFn);
+  resources.then(output);
 }
 
 export { chart };

--- a/src/chart/values.js
+++ b/src/chart/values.js
@@ -1,44 +1,21 @@
 import { patch } from '@jkcfg/mixins/src/mixins';
 
-function mergePath(values, path, value) {
-  const pathElems = path.split('.');
-  let obj = values;
-  for (const elem of pathElems.slice(0, pathElems.length - 1)) {
-    if (!Object.hasOwnProperty.call(obj, elem)) {
-      obj[elem] = {};
-    }
-    obj = obj[elem];
-  }
-  obj[pathElems[pathElems.length - 1]] = value;
-}
-
-function parseCommandLine(str) {
-  const vals = {};
-  if (str === '') {
-    return vals;
-  }
-
-  const terms = str.split(',');
-  for (const term of terms) {
-    const [path, value] = term.split('=');
-    mergePath(vals, path, value);
-  }
-  return vals;
-}
-
 // Given a means of getting parameters, and a specification of the
 // Values (including their defaults), compile a struct of values for
-// instantiating a chart.
-const values = (param, readValues) => async function compile(defaults) {
-  let vals = defaults;
-  const file = param.String('file', undefined);
-  if (file !== undefined) {
-    const fileValues = await readValues(file);
-    vals = patch(vals, fileValues);
-  }
-  const commandLine = parseCommandLine(param.String('value', ''));
-  vals = patch(vals, commandLine);
-  return vals;
+// instantiating a chart. To discriminate the values from other
+// parameters, an option is the prfix; by default, we expect the
+// command-line values to be passed as e.g., `-p values.image.tag=v1`,
+// and any file(s) (e.g., passed as `-f value.json`) to be of the form
+//
+// ```
+// values:
+//   image:
+//     repository: helloworld
+// ```
+const values = (param, opts = {}) => function compile(defaults) {
+  const { prefix = 'values' } = opts;
+  const commandLine = param.Object(prefix, {});
+  return patch(defaults, commandLine);
 };
 
 export { values };

--- a/src/chart/values.js
+++ b/src/chart/values.js
@@ -1,0 +1,44 @@
+import { patch } from '@jkcfg/mixins/src/mixins';
+
+function mergePath(values, path, value) {
+  const pathElems = path.split('.');
+  let obj = values;
+  for (const elem of pathElems.slice(0, pathElems.length - 1)) {
+    if (!Object.hasOwnProperty.call(obj, elem)) {
+      obj[elem] = {};
+    }
+    obj = obj[elem];
+  }
+  obj[pathElems[pathElems.length - 1]] = value;
+}
+
+function parseCommandLine(str) {
+  const vals = {};
+  if (str === '') {
+    return vals;
+  }
+
+  const terms = str.split(',');
+  for (const term of terms) {
+    const [path, value] = term.split('=');
+    mergePath(vals, path, value);
+  }
+  return vals;
+}
+
+// Given a means of getting parameters, and a specification of the
+// Values (including their defaults), compile a struct of values for
+// instantiating a chart.
+const values = (param, readValues) => async function compile(defaults) {
+  let vals = defaults;
+  const file = param.String('file', undefined);
+  if (file !== undefined) {
+    const fileValues = await readValues(file);
+    vals = patch(vals, fileValues);
+  }
+  const commandLine = parseCommandLine(param.String('value', ''));
+  vals = patch(vals, commandLine);
+  return vals;
+};
+
+export { values };

--- a/src/write.js
+++ b/src/write.js
@@ -1,14 +1,21 @@
 // Write all the individual resources out in directories and files
 // according to their namespace, kind and name.
-const writeResources = write => (resources) => {
+const writeResources = writeFile => (resources) => {
   resources.forEach((r) => {
     const filename = `${r.metadata.name}-${r.kind.toLowerCase()}.yaml`;
     let path = filename;
     if (r.metadata.namespace) {
       path = `${r.metadata.namespace}/${filename}`;
     }
-    write(r, path);
+    writeFile(r, path);
   });
 };
 
-export { writeResources };
+const writeStream = (writeString, writeYAML) => (resources) => {
+  resources.forEach((r) => {
+    writeString('---');
+    writeYAML(r);
+  });
+};
+
+export { writeResources, writeStream };

--- a/tests/chart_values.test.js
+++ b/tests/chart_values.test.js
@@ -1,100 +1,31 @@
 import { values } from '../src/chart/values';
 
-const doNotRead = () => { throw new Error('unexpected call to read') };
-
 function params(obj = {}) {
-  return { String: (k, d) => (obj.hasOwnProperty(k)) ? obj[k] : d };
+  return { Object: (k, d) => (obj.hasOwnProperty(k)) ? obj[k] : d };
 }
 
-test('empty values', () => {
-  const vals = values(params({value: ''}), doNotRead);
-  expect.assertions(1);
-  return vals({}).then(v => expect(v).toEqual({}));
+test('empty values and empty defaults', () => {
+  const vals = values(params({}));
+  expect(vals({})).toEqual({});
 });
 
-test('single simple path', () => {
-  const vals = values(params({ value: 'foo=bar' }), doNotRead);
-  expect.assertions(1);
-  return vals({}).then(v => expect(v).toEqual({
-    foo: 'bar'
-  }));
-});
-
-test('>1 dotted path', () => {
-  const vals = values(params({ value: 'foo.bar.baz=boo,foo.a.b.c=abc' }), doNotRead);
-  expect.assertions(1);
-  return vals({}).then(v => expect(v).toEqual({
-    foo: {
-      a: { b: { c: 'abc' }},
-      bar: {baz: 'boo'}
-    }
-  }));
+test('defaults', () => {
+  const vals = values(params({}));
+  expect(vals({app: 'foo'})).toEqual({app: 'foo'});
 });
 
 test('defaults and values', () => {
-  const vals = values(params({ value: 'foo.boo=baz' }), doNotRead);
-  const defaults = {
-    foo: {
-      bar: 1,
+  const commandLine = {image: {repository: 'helloworld'}};
+  const vals = values(params({values: commandLine}));
+  expect(vals({image: {tag: 'v1'}})).toEqual({
+    image: {
+      repository: 'helloworld',
+      tag: 'v1',
     }
-  };
-  expect.assertions(1);
-  return vals(defaults).then(v => expect(v).toEqual({
-    foo: {
-      bar: 1,
-      boo: 'baz'
-    }
-  }));
+  });
 });
 
-test('values from file', () => {
-  const readFile = (f) => {
-    switch (f) {
-    case 'values.yaml':
-      return { image: { tag: 'v2' }};
-    default:
-      throw new Error(`unexpected read of ${f}`)
-    }
-  };
-  const vals = values(params({ file: 'values.yaml' }), readFile);
-  const defaults = {
-    image: {
-      repository: 'helloworld',
-      tag: 'v1'
-    }
-  };
-
-  expect.assertions(1);
-  return vals(defaults).then(v => expect(v).toEqual({
-    image: {
-      repository: 'helloworld',
-      tag: 'v2'
-    }
-  }));
-});
-
-test('command-line values take precedence', () => {
-  const readFile = (f) => {
-    switch (f) {
-    case 'values.yaml':
-      return { image: { tag: 'v2' }};
-    default:
-      throw new Error(`unexpected read of ${f}`)
-    }
-  };
-  const vals = values(params({ value: 'image.tag=v3', file: 'values.yaml' }), readFile);
-  const defaults = {
-    image: {
-      repository: 'helloworld',
-      tag: 'v1'
-    }
-  };
-
-  expect.assertions(1);
-  return vals(defaults).then(v => expect(v).toEqual({
-    image: {
-      repository: 'helloworld',
-      tag: 'v3'
-    }
-  }));
+test('values override defaults', () => {
+  const vals = values(params({values: {app: 'bar'}}));
+  expect(vals({app: 'foo'})).toEqual({app: 'bar'});
 });

--- a/tests/chart_values.test.js
+++ b/tests/chart_values.test.js
@@ -1,0 +1,100 @@
+import { values } from '../src/chart/values';
+
+const doNotRead = () => { throw new Error('unexpected call to read') };
+
+function params(obj = {}) {
+  return { String: (k, d) => (obj.hasOwnProperty(k)) ? obj[k] : d };
+}
+
+test('empty values', () => {
+  const vals = values(params({value: ''}), doNotRead);
+  expect.assertions(1);
+  return vals({}).then(v => expect(v).toEqual({}));
+});
+
+test('single simple path', () => {
+  const vals = values(params({ value: 'foo=bar' }), doNotRead);
+  expect.assertions(1);
+  return vals({}).then(v => expect(v).toEqual({
+    foo: 'bar'
+  }));
+});
+
+test('>1 dotted path', () => {
+  const vals = values(params({ value: 'foo.bar.baz=boo,foo.a.b.c=abc' }), doNotRead);
+  expect.assertions(1);
+  return vals({}).then(v => expect(v).toEqual({
+    foo: {
+      a: { b: { c: 'abc' }},
+      bar: {baz: 'boo'}
+    }
+  }));
+});
+
+test('defaults and values', () => {
+  const vals = values(params({ value: 'foo.boo=baz' }), doNotRead);
+  const defaults = {
+    foo: {
+      bar: 1,
+    }
+  };
+  expect.assertions(1);
+  return vals(defaults).then(v => expect(v).toEqual({
+    foo: {
+      bar: 1,
+      boo: 'baz'
+    }
+  }));
+});
+
+test('values from file', () => {
+  const readFile = (f) => {
+    switch (f) {
+    case 'values.yaml':
+      return { image: { tag: 'v2' }};
+    default:
+      throw new Error(`unexpected read of ${f}`)
+    }
+  };
+  const vals = values(params({ file: 'values.yaml' }), readFile);
+  const defaults = {
+    image: {
+      repository: 'helloworld',
+      tag: 'v1'
+    }
+  };
+
+  expect.assertions(1);
+  return vals(defaults).then(v => expect(v).toEqual({
+    image: {
+      repository: 'helloworld',
+      tag: 'v2'
+    }
+  }));
+});
+
+test('command-line values take precedence', () => {
+  const readFile = (f) => {
+    switch (f) {
+    case 'values.yaml':
+      return { image: { tag: 'v2' }};
+    default:
+      throw new Error(`unexpected read of ${f}`)
+    }
+  };
+  const vals = values(params({ value: 'image.tag=v3', file: 'values.yaml' }), readFile);
+  const defaults = {
+    image: {
+      repository: 'helloworld',
+      tag: 'v1'
+    }
+  };
+
+  expect.assertions(1);
+  return vals(defaults).then(v => expect(v).toEqual({
+    image: {
+      repository: 'helloworld',
+      tag: 'v3'
+    }
+  }));
+});


### PR DESCRIPTION
Minimal example of how to do something like a Helm chart. The entry point used is a new library module `@jkcfg/kubernetes/chart`, which mostly just does the work of compiling the values for instantiating the chart.
