### PR TITLE
[WIP] Second chart example, using templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,4 @@ clean:
 
 test: gen
 	npm test
+	npm run lint

--- a/examples/chart/README.md
+++ b/examples/chart/README.md
@@ -1,13 +1,14 @@
-# Analogue to a Helm chart
+# Analogue to Helm charts
 
 This example shows a Helm chart analogue for `jk`. The aim is to have
 a template to which you can supply values upon
 instantiation. Secondarily, the "chart" can be published, and reused
-in another configuration. It's not a goal here to reproduce the
-runtime bits of Helm -- that is, keeping track of which charts have
-been released to the cluster.
+in another configuration.
 
-## To run the example
+It's not a goal here to reproduce the runtime bits of Helm -- that is,
+keeping track of which charts have been released to the cluster.
+
+## To run the examples
 
 (in this directory)
 
@@ -16,7 +17,7 @@ npm install '@jkcfg/kubernetes'
 # or: make -C ../.. dist && npm install ../../dist
 
 # run the chart with defaults
-jk run ./index.js
+jk run ./index.js # or ./index2.js
 
 # run the chart with some value parameter overrides
 jk run ./index.js -p values.app=goodbye -f ./values.json
@@ -45,7 +46,9 @@ docs.
 
 Taking these bits one by one ..
 
-**Generating resources**
+### Generating resources
+
+**index.js**
 
 The template function (in `resources.js`) is in large part an object
 literal, with a sprinkling of variable references and interpolated
@@ -59,21 +62,41 @@ If you did prefer to have separate files, you could put each resource
 definition (as a function) in its own file as a module, and import
 them all to instantiate them.
 
-**Collecting values**
+**index2.js**
+
+This example demonstrates the use of
+`@jkcfg/kubernetes/chart/template` to load templates from files (the
+files are in `templates/`). The templates are close to Helm's `gotpl`,
+in their mode of use and syntax.
+
+### Collecting values
 
 The `chart(...)` procedure uses the parameter-passing mechanism of
 `jk` to obtain values from the command-line or from files. To keep
 those separate from parameters intended for other purposes, it assumes
-the `values` prefix (arbitrarily, and because it's the prefix used
-with Helm charts).
+the `values` prefix (because it's the prefix used with Helm charts).
 
 Since `jk` merges the parameters for us, there's little work to do
 other than merging the supplied values with the defaults as given in
-code. The defaults could also be loaded from a file; `chart` copes
-with getting a promise of defaults.
+code. The defaults can also be loaded from a file; `chart` copes with
+getting a promise of defaults.
 
-**Printing the result**
+### Printing results
 
-The chart procedure chooses how to print each resource depending on
-its representation -- either an object (as produced by resources.js),
-or a string (as a templating library would yield).
+The two examples have slightly different ways of outputting their
+results. `index.js` can simply print a YAML stream using `std.write`,
+because it has objects representing the resources (and that's what
+`std.write` expects).
+
+If the resources need to be specialised in some way unanticipated by
+the chart, you can do further transformations on the objects before
+printing them; e.g,. using parts of the overlay module.
+
+`index2.js` gets string values from running the templates, so it
+effectively just prints each string with the YAML document delimiter
+in between.
+
+Useful transformations on the strings are tricky; this is a
+consequence of using textual templates. But it should be possible in
+the future to feed strings to the `jk` runtime to get back objects,
+and unlock that possibility.

--- a/examples/chart/README.md
+++ b/examples/chart/README.md
@@ -1,6 +1,6 @@
 # Analogue to a Helm chart
 
-This examples shows a Helm chart analogue for `jk`. The aim is to have
+This example shows a Helm chart analogue for `jk`. The aim is to have
 a template to which you can supply values upon
 instantiation. Secondarily, the "chart" can be published, and reused
 in another configuration. It's not a goal here to reproduce the

--- a/examples/chart/index.js
+++ b/examples/chart/index.js
@@ -12,4 +12,6 @@ const defaults = {
   }
 };
 
-chart(resources, defaults, std.param);
+const output = resources => std.log(resources, { format: std.Format.YAMLStream });
+
+chart(resources, defaults, std.param).then(output);

--- a/examples/chart/index2.js
+++ b/examples/chart/index2.js
@@ -2,6 +2,7 @@
 
 import { chart } from '@jkcfg/kubernetes/chart';
 import { load } from '@jkcfg/kubernetes/chart/template';
+import { writeYAMLStream } from '@jkcfg/kubernetes/write';
 import * as resource from '@jkcfg/std/resource';
 import std from '@jkcfg/std';
 
@@ -16,4 +17,9 @@ const defaults = {
 
 const templates = load(resource);
 
-chart(templates, defaults, std.param);
+// Because we get strings out of the templates, rather than objects,
+// we don't need to serialise them; so, use writeYAMLStream, which we
+// can specialise so that it just splats strings to stdout.
+const output = writeYAMLStream(std.log, std.log);
+
+chart(templates, defaults, std.param).then(output);

--- a/examples/chart/index2.js
+++ b/examples/chart/index2.js
@@ -1,0 +1,31 @@
+// Example of a Helm chart analogue, using handlebars
+
+import handlebars from 'handlebars/lib/handlebars.js';
+import { chart } from '@jkcfg/kubernetes/chart';
+import std from '@jkcfg/std';
+
+const defaults = {
+  name: 'helloworld',
+  app: 'hello',
+  image: {
+    repository: 'weaveworks/helloworld',
+    tag: 'v1'
+  }
+};
+
+const isTemplateFile = info => (!info.isDir && info.name.endsWith('.yaml'));
+
+// filename -> Promise (values -> resource)
+async function loadTemplate({ path }) {
+  const file = await std.read(path, { encoding: std.Encoding.String });
+  const template = handlebars.compile(file);
+  return values => template({ values });
+}
+
+async function resources(values) /* Promise [resource] */ {
+  const dir = std.dir('templates');
+  const templates = await Promise.all(dir.files.filter(isTemplateFile).map(loadTemplate));
+  return templates.map(t => t(values));
+}
+
+chart(resources, defaults, std.param);

--- a/examples/chart/index2.js
+++ b/examples/chart/index2.js
@@ -15,7 +15,8 @@ const defaults = {
   }
 };
 
-const templates = load(resource);
+const readString = path => resource.read(path, { encoding: std.Encoding.String });
+const templates = load({ readString, ...resource });
 
 // Because we get strings out of the templates, rather than objects,
 // we don't need to serialise them; so, use writeYAMLStream, which we

--- a/examples/chart/index2.js
+++ b/examples/chart/index2.js
@@ -1,7 +1,7 @@
 // Example of a Helm chart analogue, using handlebars
 
-import handlebars from 'handlebars/lib/handlebars.js';
 import { chart } from '@jkcfg/kubernetes/chart';
+import { load } from '@jkcfg/kubernetes/chart/template';
 import * as resource from '@jkcfg/std/resource';
 import std from '@jkcfg/std';
 
@@ -14,19 +14,6 @@ const defaults = {
   }
 };
 
-const isTemplateFile = info => (!info.isDir && info.name.endsWith('.yaml'));
+const templates = load(resource);
 
-// filename -> Promise (values -> resource)
-async function loadTemplate({ path }) {
-  const file = await resource.read(path, { encoding: std.Encoding.String });
-  const template = handlebars.compile(file);
-  return values => template({ values });
-}
-
-async function resources(values) /* Promise [resource] */ {
-  const dir = resource.dir('templates');
-  const templates = await Promise.all(dir.files.filter(isTemplateFile).map(loadTemplate));
-  return templates.map(t => t(values));
-}
-
-chart(resources, defaults, std.param);
+chart(templates, defaults, std.param);

--- a/examples/chart/index2.js
+++ b/examples/chart/index2.js
@@ -2,6 +2,7 @@
 
 import handlebars from 'handlebars/lib/handlebars.js';
 import { chart } from '@jkcfg/kubernetes/chart';
+import * as resource from '@jkcfg/std/resource';
 import std from '@jkcfg/std';
 
 const defaults = {
@@ -17,13 +18,13 @@ const isTemplateFile = info => (!info.isDir && info.name.endsWith('.yaml'));
 
 // filename -> Promise (values -> resource)
 async function loadTemplate({ path }) {
-  const file = await std.read(path, { encoding: std.Encoding.String });
+  const file = await resource.read(path, { encoding: std.Encoding.String });
   const template = handlebars.compile(file);
   return values => template({ values });
 }
 
 async function resources(values) /* Promise [resource] */ {
-  const dir = std.dir('templates');
+  const dir = resource.dir('templates');
   const templates = await Promise.all(dir.files.filter(isTemplateFile).map(loadTemplate));
   return templates.map(t => t(values));
 }

--- a/examples/chart/resources.js
+++ b/examples/chart/resources.js
@@ -1,20 +1,31 @@
-import { apps } from '@jkcfg/kubernetes/api';
+import { core, apps } from '@jkcfg/kubernetes/api';
 
 function resources(Values) {
-  return [new apps.v1.Deployment(Values.name, {
-    spec: {
-      template: {
-        labels: {app: Values.app },
-        spec: {
-          containers: {
-            'hello': {
-              image: `${Values.image.repository}:${Values.image.tag}`
+  return [
+    new apps.v1.Deployment(`${Values.name}-dep`, {
+      spec: {
+        template: {
+          labels: {app: Values.app },
+          spec: {
+            containers: {
+              'hello': {
+                image: `${Values.image.repository}:${Values.image.tag}`
+              }
             }
           }
         }
       }
-    }
-  })];
+    }),
+    new core.v1.Service(`${Values.name}-svc`, {
+      metadata: {
+        labels: { app: Values.app },
+      },
+      spec: {
+        selector: {
+          app: Values.app,
+        }
+      }
+    })];
 }
 
 export default resources;

--- a/examples/chart/templates/deployment.yaml
+++ b/examples/chart/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 meta:
-  name: '{{values.name}}'
+  name: '{{values.name}}-dep'
 spec:
   template:
     labels:

--- a/examples/chart/templates/deployment.yaml
+++ b/examples/chart/templates/deployment.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+meta:
+  name: '{{values.name}}'
+spec:
+  template:
+    labels:
+      app: '{{values.app}}'
+      spec:
+        containers:
+        - name: hello
+          image: '{{values.image.repository}}:{{values.image.tag}}'

--- a/examples/chart/templates/service.yaml
+++ b/examples/chart/templates/service.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Service
+meta:
+  name: '{{values.name}}-svc'
+spec:
+  selector:
+    app: '{{values.app}}'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@jkcfg/kubernetes",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1671,10 +1671,9 @@
       }
     },
     "commander": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-      "dev": true,
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
       "optional": true
     },
     "component-emitter": {
@@ -2535,7 +2534,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2549,21 +2549,23 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.6"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -2576,17 +2578,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2627,7 +2632,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "fs.realpath": {
@@ -2642,14 +2647,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "glob": {
@@ -2658,12 +2663,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-unicode": {
@@ -2678,7 +2683,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": "^2.1.0"
           }
         },
         "ignore-walk": {
@@ -2687,7 +2692,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "3.0.4"
+            "minimatch": "^3.0.4"
           }
         },
         "inflight": {
@@ -2696,14 +2701,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2715,8 +2721,9 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
@@ -2729,22 +2736,25 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.0"
           }
         },
         "minizlib": {
@@ -2753,13 +2763,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2776,9 +2787,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.9",
-            "iconv-lite": "0.4.21",
-            "sax": "1.2.4"
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -2787,16 +2798,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.3",
-            "mkdirp": "0.5.1",
-            "needle": "2.2.0",
-            "nopt": "4.0.1",
-            "npm-packlist": "1.1.10",
-            "npmlog": "4.1.2",
-            "rc": "1.2.7",
-            "rimraf": "2.6.2",
-            "semver": "5.5.0",
-            "tar": "4.4.1"
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.0",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
           }
         },
         "nopt": {
@@ -2805,8 +2816,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npm-bundled": {
@@ -2821,8 +2832,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npmlog": {
@@ -2831,16 +2842,17 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2852,8 +2864,9 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -2874,8 +2887,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -2896,10 +2909,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.5.1",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "^0.5.1",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -2916,13 +2929,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "rimraf": {
@@ -2931,13 +2944,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2973,10 +2987,11 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
@@ -2985,15 +3000,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -3008,13 +3024,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.2"
           }
         },
         "util-deprecate": {
@@ -3029,18 +3045,20 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3135,12 +3153,11 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
-      "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
-      "dev": true,
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
+      "integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
       "requires": {
-        "async": "^2.5.0",
+        "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4"
@@ -4492,8 +4509,7 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mixin-deep": {
       "version": "1.3.1",
@@ -4588,6 +4604,11 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "neo-async": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
+      "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA=="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -4795,7 +4816,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
@@ -4804,8 +4824,7 @@
         "wordwrap": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-          "dev": true
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
         }
       }
     },
@@ -6002,8 +6021,7 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-resolve": {
       "version": "0.5.2",
@@ -6469,13 +6487,12 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-      "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
-      "dev": true,
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.2.tgz",
+      "integrity": "sha512-imog1WIsi9Yb56yRt5TfYVxGmnWs3WSGU73ieSOlMVFwhJCA9W8fqFFMMj4kgDqiS/80LGdsYnWL7O9UcjEBlg==",
       "optional": true,
       "requires": {
-        "commander": "~2.17.1",
+        "commander": "~2.19.0",
         "source-map": "~0.6.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "url": "https://github.com/jkcfg/kubernetes/issues"
   },
   "dependencies": {
-    "@jkcfg/mixins": "^0.1.2"
+    "@jkcfg/mixins": "^0.1.2",
+    "handlebars": "^4.1.1"
   },
   "description": "jk Kubernetes library",
   "devDependencies": {
@@ -40,15 +41,21 @@
     "globals": {
       "ts-jest": {
         "diagnostics": {
-        "ignoreCodes": [151001]
+          "ignoreCodes": [
+            151001
+          ]
         }
       }
     },
     "testMatch": [
       "<rootDir>/tests/*.test.js"
     ],
-    "transformIgnorePatterns": ["<rootDir>/dist/"],
-    "modulePathIgnorePatterns": ["<rootDir>/dist/"],
+    "transformIgnorePatterns": [
+      "<rootDir>/dist/"
+    ],
+    "modulePathIgnorePatterns": [
+      "<rootDir>/dist/"
+    ],
     "moduleDirectories": [
       "<rootDir>/node_modules"
     ]

--- a/src/chart/index.js
+++ b/src/chart/index.js
@@ -1,27 +1,9 @@
-import std from '@jkcfg/std';
-import { writeStream } from '../write';
 import { values } from './values';
-
-const printString = s => std.write(s, '');
-const printYAML = s => std.write(s, '', { format: std.Format.YAML });
-
-function printValue(val) {
-  switch (typeof val) {
-  case 'string':
-    return printString(val);
-  case 'object':
-  default:
-    return printYAML(val);
-  }
-}
-
-const output = writeStream(printString, printValue);
 
 function chart(resourcesFn, defaults, param) {
   // lift defaults into Promise, since it may or may not be one
   const vals = Promise.resolve(defaults).then(values(param));
-  const resources = vals.then(resourcesFn);
-  resources.then(output);
+  return vals.then(resourcesFn);
 }
 
 export { chart };

--- a/src/chart/template.js
+++ b/src/chart/template.js
@@ -1,0 +1,21 @@
+import handlebars from 'handlebars/lib/handlebars.js';
+import std from '@jkcfg/std';
+
+const isTemplateFile = info => (!info.isDir && info.name.endsWith('.yaml'));
+
+// read x filename -> Promise (values -> resource)
+async function loadTemplate(read, { path }) {
+  const file = await read(path, { encoding: std.Encoding.String });
+  const template = handlebars.compile(file);
+  return values => template({ values });
+}
+
+// { read, dir } -> values -> Promise [resource]
+const load = ({ read, dir }) => async function resources(values) {
+  const d = dir('templates');
+  const loadTempl = path => loadTemplate(read, path);
+  const templates = await Promise.all(d.files.filter(isTemplateFile).map(loadTempl));
+  return templates.map(t => t(values));
+}
+
+export { load };

--- a/src/chart/template.js
+++ b/src/chart/template.js
@@ -1,21 +1,20 @@
 import handlebars from 'handlebars/lib/handlebars.js';
-import std from '@jkcfg/std';
 
 const isTemplateFile = info => (!info.isDir && info.name.endsWith('.yaml'));
 
-// read x filename -> Promise (values -> resource)
-async function loadTemplate(read, { path }) {
-  const file = await read(path, { encoding: std.Encoding.String });
+// readString x filename -> Promise (values -> resource)
+async function loadTemplate(readString, path) {
+  const file = await readString(path);
   const template = handlebars.compile(file);
   return values => template({ values });
 }
 
-// { read, dir } -> values -> Promise [resource]
-const load = ({ read, dir }) => async function resources(values) {
+// { readString, dir } -> values -> Promise [string]
+const load = ({ readString, dir }) => async function resources(values) {
   const d = dir('templates');
-  const loadTempl = path => loadTemplate(read, path);
+  const loadTempl = info => loadTemplate(readString, info.path);
   const templates = await Promise.all(d.files.filter(isTemplateFile).map(loadTempl));
   return templates.map(t => t(values));
-}
+};
 
 export { load };

--- a/src/chart/template.js
+++ b/src/chart/template.js
@@ -1,4 +1,4 @@
-import handlebars from 'handlebars/lib/handlebars.js';
+import handlebars from 'handlebars/lib/handlebars';
 
 const isTemplateFile = info => (!info.isDir && info.name.endsWith('.yaml'));
 

--- a/src/write.js
+++ b/src/write.js
@@ -11,11 +11,14 @@ const writeResources = writeFile => (resources) => {
   });
 };
 
-const writeStream = (writeString, writeYAML) => (resources) => {
+// writeStream gives a little more flexibility for writing out a list
+// of resources than std.write. This is useful if you generated
+// strings instead of objects for your resources, for example.
+const writeYAMLStream = (writeString, writeResource) => (resources) => {
   resources.forEach((r) => {
     writeString('---');
-    writeYAML(r);
+    writeResource(r);
   });
 };
 
-export { writeResources, writeStream };
+export { writeResources, writeYAMLStream };

--- a/tests/chart_templates.test.js
+++ b/tests/chart_templates.test.js
@@ -1,0 +1,42 @@
+import { load } from '../src/chart/template';
+
+const dir = (path) => {
+  if (path === 'templates') {
+    return {
+      path,
+      files: [
+        { path: `templates/foo.yaml`, isDir: false, name: 'foo.yaml' },
+        { path: `templates/bar.yaml`, isDir: false, name: 'bar.yaml' },
+      ],
+    };
+  }
+  throw new Error(`dir ${path} does not exist`);
+};
+
+const fooYAML = `
+This is just some text.
+`;
+
+const barYAML = `
+This is some text with a {{ values.variable }} reference.
+`;
+
+const readString = (path) => {
+  switch (path) {
+  case 'templates/foo.yaml':
+    return fooYAML;
+  case 'templates/bar.yaml':
+    return barYAML;
+  }
+  throw new Error(`file ${path} not found`);
+};
+
+test('load a dir of templates', () => {
+  const templateLoad = load({ dir, readString });
+  const out = templateLoad({ variable: 'handlebars' });
+  expect.assertions(2);
+  return out.then(([foo, bar]) => {
+    expect(foo).toEqual(fooYAML);
+    expect(bar.trim()).toEqual('This is some text with a handlebars reference.');
+  });
+});


### PR DESCRIPTION
This chart example uses handlebars templates to generate resources,
rather than constructing them as object literals.

It needs

    npm install handlebars

and depends on a fix for https://github.com/jkcfg/jk/issues/131.