### PR TITLE
Short format for Kubernetes resources

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,6 +18,7 @@
     "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
     "indent": ["error", 2, {"SwitchCase": 0, "CallExpression": {"arguments": "first"}}],
     "no-restricted-syntax": ["error", "ForInStatement", "LabeledStatement", "WithStatement"],
-    "object-curly-newline": ["error", { "ImportDeclaration": "never" }]
+    "object-curly-newline": ["error", { "ImportDeclaration": "never" }],
+    "no-use-before-define": ["error", { "functions": false, "classes": true }]  }
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -19,6 +19,6 @@
     "indent": ["error", 2, {"SwitchCase": 0, "CallExpression": {"arguments": "first"}}],
     "no-restricted-syntax": ["error", "ForInStatement", "LabeledStatement", "WithStatement"],
     "object-curly-newline": ["error", { "ImportDeclaration": "never" }],
-    "no-use-before-define": ["error", { "functions": false, "classes": true }]  }
+    "no-use-before-define": ["error", { "functions": false, "classes": true }]
   }
 }

--- a/examples/short/index.js
+++ b/examples/short/index.js
@@ -1,0 +1,27 @@
+// An example of using shortened forms to represent resources.
+
+import { long } from '@jkcfg/kubernetes/short';
+import std from '@jkcfg/std';
+
+const deployment = {
+  deployment: {
+    name: 'foo-dep',
+    namespace: 'foo-ns',
+    labels: { app: 'hello' },
+    containers: [
+    ],
+  }
+};
+
+const service = {
+  service: {
+    name: 'foo-svc',
+    namespace: 'foo-ns',
+    selector: { app: 'hello' },
+  },
+};
+
+std.log('---\n', { format: std.Format.Raw });
+std.log(long(deployment), { format: std.Format.YAML });
+std.log('---\n', { format: std.Format.Raw });
+std.log(long(service), { format: std.Format.YAML });

--- a/examples/short/index.js
+++ b/examples/short/index.js
@@ -8,7 +8,14 @@ const deployment = {
     name: 'foo-dep',
     namespace: 'foo-ns',
     labels: { app: 'hello' },
+    pod_meta: {
+      labels: { name: 'foo-pod' },
+    },
     containers: [
+      {
+        name: 'hello',
+        image: 'helloworld',
+      },
     ],
   }
 };

--- a/examples/short/index.js
+++ b/examples/short/index.js
@@ -7,10 +7,14 @@ const deployment = {
   deployment: {
     name: 'foo-dep',
     namespace: 'foo-ns',
-    labels: { app: 'hello' },
     pod_meta: {
-      labels: { name: 'foo-pod' },
+      labels: { app: 'hello' },
     },
+    recreate: false,
+    replicas: 5,
+    max_extra: 1,
+    max_unavailable: 2,
+    progress_deadline: 30,
     containers: [
       {
         name: 'hello',

--- a/examples/short/index.js
+++ b/examples/short/index.js
@@ -1,7 +1,7 @@
 // An example of using shortened forms to represent resources.
 
+import { valuesForGenerate } from '@jkcfg/kubernetes/generate';
 import { long } from '@jkcfg/kubernetes/short';
-import std from '@jkcfg/std';
 
 const deployment = {
   deployment: {
@@ -21,7 +21,4 @@ const service = {
   },
 };
 
-std.log('---\n', { format: std.Format.Raw });
-std.log(long(deployment), { format: std.Format.YAML });
-std.log('---\n', { format: std.Format.Raw });
-std.log(long(service), { format: std.Format.YAML });
+export default valuesForGenerate([deployment, service].map(long));

--- a/src/short/index.js
+++ b/src/short/index.js
@@ -1,0 +1,63 @@
+// "Short" forms for API objects.
+//
+// This is the inspiration and target format: https://docs.koki.io/short/
+
+import { apps, core } from '../api';
+import { transform, valueMap } from './transform';
+
+// Take a constructor (e.g., from the API) and return a transformer
+// that will construct the API resource given a API resource "shape".
+function makeResource(Ctor, spec) {
+  return (v) => {
+    const shape = transform(spec, v);
+    return new Ctor(shape.metadata.name, shape);
+  };
+}
+
+const objectMeta = {
+  // not strictly metadata, but common to everything
+  apiVersion: 'version',
+  // `kind` is not transformed here, rather used as the dispatch
+  // mechanism, and supplied by the specific API resource constructor
+
+  // ObjectMeta
+  name: 'metadata.name',
+  namespace: 'metadata.namespace',
+  labels: 'metadata.labels',
+  annotations: 'metadata.annotations',
+};
+
+const workloadSpec = {
+  ...objectMeta,
+};
+
+const serviceSpec = {
+  ...objectMeta,
+  cname: 'spec.externalName',
+  type: valueMap('spec.type', {
+    'cluster-ip': 'ClusterIP',
+    'load-balancer': 'LoadBalancer',
+    'node-port': 'NodePort',
+  }),
+  selector: 'spec.selector',
+};
+
+const transforms = {
+  deployment: makeResource(apps.v1.Deployment, workloadSpec),
+  service: makeResource(core.v1.Service, serviceSpec),
+};
+
+// TODO all the other ones.
+// TODO register new transforms (e.g., for custom resources).
+
+// long takes a short description and turns it into a full API object.
+function long(obj) {
+  const [kind] = Object.keys(obj);
+  const tx = transforms[kind];
+  if (tx === undefined) {
+    throw new Error(`unknown kind: ${kind}`);
+  }
+  return tx(obj[kind]);
+}
+
+export { long };

--- a/src/short/index.js
+++ b/src/short/index.js
@@ -2,58 +2,12 @@
 //
 // This is the inspiration and target format: https://docs.koki.io/short/
 
-import { apps, core } from '../api';
-import { transform, valueMap } from './transform';
-
-// Take a constructor (e.g., from the API) and return a transformer
-// that will construct the API resource given a API resource "shape".
-function makeResource(Ctor, spec) {
-  return (v) => {
-    const shape = transform(spec, v);
-    return new Ctor(shape.metadata.name, shape);
-  };
-}
-
-const objectMeta = {
-  // not strictly metadata, but common to everything
-  apiVersion: 'version',
-  // `kind` is not transformed here, rather used as the dispatch
-  // mechanism, and supplied by the specific API resource constructor
-
-  // ObjectMeta
-  name: 'metadata.name',
-  namespace: 'metadata.namespace',
-  labels: 'metadata.labels',
-  annotations: 'metadata.annotations',
-};
-
-const workloadSpec = {
-  ...objectMeta,
-};
-
-const serviceSpec = {
-  ...objectMeta,
-  cname: 'spec.externalName',
-  type: valueMap('spec.type', {
-    'cluster-ip': 'ClusterIP',
-    'load-balancer': 'LoadBalancer',
-    'node-port': 'NodePort',
-  }),
-  selector: 'spec.selector',
-};
-
-const transforms = {
-  deployment: makeResource(apps.v1.Deployment, workloadSpec),
-  service: makeResource(core.v1.Service, serviceSpec),
-};
-
-// TODO all the other ones.
-// TODO register new transforms (e.g., for custom resources).
+import kinds from './kinds';
 
 // long takes a short description and turns it into a full API object.
 function long(obj) {
   const [kind] = Object.keys(obj);
-  const tx = transforms[kind];
+  const tx = kinds[kind];
   if (tx === undefined) {
     throw new Error(`unknown kind: ${kind}`);
   }

--- a/src/short/kinds.js
+++ b/src/short/kinds.js
@@ -1,5 +1,5 @@
 import { apps, core } from '../api';
-import { transform, valueMap, mapper } from './transform';
+import { transform, valueMap, mapper, drop } from './transform';
 
 // Take a constructor (e.g., from the API) and return a transformer
 // that will construct the API resource given a API resource "shape".
@@ -294,8 +294,7 @@ const containerSpec = {
 };
 
 /* eslint-disable object-shorthand */
-const podSpec = {
-  ...objectMeta,
+const podTemplateSpec = {
   volumes: volumes,
   affinity: affinities,
   node: 'spec.nodeName',
@@ -325,8 +324,15 @@ const podSpec = {
   gids: 'spec.securityContext.supplementalGroups',
 };
 
-const workloadSpec = {
+const podSpec = {
   ...objectMeta,
+  ...podTemplateSpec,
+};
+
+const deploymentSpec = {
+  ...objectMeta,
+  pod_meta: drop('spec.template', objectMeta),
+  ...drop('spec.template', podTemplateSpec),
 };
 
 function sessionAffinity(value) {
@@ -376,6 +382,6 @@ const serviceSpec = {
 export default {
   namespace: makeResource(core.v1.Namespace, objectMeta),
   pod: makeResource(core.v1.Pod, podSpec),
-  deployment: makeResource(apps.v1.Deployment, workloadSpec),
+  deployment: makeResource(apps.v1.Deployment, deploymentSpec),
   service: makeResource(core.v1.Service, serviceSpec),
 };

--- a/src/short/kinds.js
+++ b/src/short/kinds.js
@@ -1,0 +1,381 @@
+import { apps, core } from '../api';
+import { transform, valueMap, thread } from './transform';
+
+// Take a constructor (e.g., from the API) and return a transformer
+// that will construct the API resource given a API resource "shape".
+function makeResource(Ctor, spec) {
+  return (v) => {
+    const shape = transform(spec, v);
+    let name = '';
+    if (shape && shape.metadata && shape.metadata.name) {
+      ({ metadata: { name } } = shape);
+    }
+    return new Ctor(name, shape);
+  };
+}
+
+const objectMeta = {
+  // not strictly metadata, but common to everything
+  version: 'apiVersion',
+  // `kind` is not transformed here, rather used as the dispatch
+  // mechanism, and supplied by the specific API resource constructor
+
+  // ObjectMeta
+  name: 'metadata.name',
+  namespace: 'metadata.namespace',
+  labels: 'metadata.labels',
+  annotations: 'metadata.annotations',
+};
+
+function volumeSpec(name, vol) {
+  if (typeof vol === 'string') {
+    return volumeSpec(name, { vol_type: vol });
+  }
+  const { vol_type: volType } = vol;
+  let spec;
+  switch (volType) {
+  case 'empty_dir':
+    spec = {
+      name,
+      emptyDir: transform({
+        max_size: 'sizeLimit',
+        medium: valueMap('medium', {
+          memory: 'Memory',
+        }),
+      }, vol),
+    };
+    break;
+  default:
+    throw new Error(`vol_type ${volType} not supported`);
+  }
+
+  return spec;
+}
+
+function volumes(volumeMap) {
+  const vols = [];
+  // In the original shorts, the value of `name` is used in a
+  // volume(mount)'s `store` field to refer back to a particular
+  // volume. This _could_ be checked at generation time, with a little
+  // extra bookkeeping.
+  for (const [name, spec] of Object.entries(volumeMap)) {
+    vols.push(volumeSpec(name, spec));
+  }
+  return {
+    spec: { volumes: vols },
+  };
+}
+
+function affinities() {
+  throw new Error('affinity not supported yet');
+}
+
+function hostAliases(specs) {
+  const aliases = [];
+  for (const spec of specs) {
+    const [ip, ...hostnames] = spec.split(' ');
+    aliases.push({ ip, hostnames });
+  }
+  return {
+    spec: { aliases },
+  };
+}
+
+function hostMode(flags) {
+  const spec = {};
+  for (const flag of flags) {
+    switch (flag) {
+    case 'net':
+      spec.hostNetwork = true;
+      break;
+    case 'pid':
+      spec.hostPID = true;
+      break;
+    case 'ipc':
+      spec.hostIPC = true;
+      break;
+    default:
+      throw new Error(`host mode flag ${flag} unexpected`);
+    }
+  }
+  return { spec };
+}
+
+function hostName(h) {
+  const [hostname, ...subdomain] = h.split('.');
+  const spec = { hostname };
+  if (subdomain.length > 0) {
+    spec.subdomain = subdomain.join('.');
+  }
+  return { spec };
+}
+
+function account(accountStr) {
+  const [name, maybeAuto] = accountStr.split(':');
+  const spec = { serviceAccountName: name };
+  if (maybeAuto === 'auto') {
+    spec.autoMountServiceAccountToken = true;
+  }
+  return { spec };
+}
+
+function tolerations() {
+  throw new Error('tolerations not implemented yet');
+}
+
+function priority(p) {
+  const { value } = p;
+  const spec = { priority: value };
+  if (p.class !== undefined) {
+    spec.priorityClassName = p.class;
+  }
+  return { spec };
+}
+
+function envVars(envs) {
+  const env = [];
+  const envFrom = [];
+  /* eslint-disable no-continue */
+  for (const e of envs) {
+    if (typeof e === 'string') {
+      const [name, value] = e.split('=');
+      env.push({ name, value });
+      continue;
+    }
+
+    // There are two kinds of env entry using references: `env` which
+    // refers to a specific field in a ConfigMap or Secret, and
+    // `envFrom` which imports all values from ConfigMap or Secret,
+    // possibly with a prefix. In shorts, which is meant is determined
+    // by the presence of a third segment of the (':'-delimited)
+    // `from` value.
+    const { from, key, required } = e;
+    const [kind, name, field] = from.split(':');
+
+    // If no field is given in `from`, it's an `envFrom`
+    if (field === undefined) {
+      const ref = { name };
+      if (required !== undefined) ref.optional = !required;
+      const allFrom = { prefix: key };
+      switch (kind) {
+      case 'config':
+        allFrom.configMapRef = ref;
+        break;
+      case 'secret':
+        allFrom.secretRef = ref;
+        break;
+      default:
+        throw new Error(`kind for envVar of ${kind} not supported`);
+      }
+      envFrom.push(allFrom);
+      continue;
+    }
+
+    // If a field is given, it's an `env`. In this case, the `key`
+    // value is the name of the env var, and the field is the key in
+    // the referenced resource.
+    const ref = { key: field, name };
+    if (required !== undefined) ref.optional = !required;
+    const valueFrom = {};
+    switch (kind) {
+    case 'config':
+      valueFrom.configMapKeyRef = ref;
+      break;
+    case 'secret':
+      valueFrom.secretKeyRef = ref;
+      break;
+    default:
+      throw new Error(`kind for envVar of ${kind} not supported`);
+    }
+    env.push({ name: key, valueFrom });
+  }
+  return { env, envFrom };
+}
+
+function resource(res) {
+  return ({ min, max }) => {
+    const resources = {};
+    if (min !== undefined) resources.requests = { [res]: min };
+    if (max !== undefined) resources.limits = { [res]: max };
+    return { resources };
+  };
+}
+
+const action = {
+  command: args => ({ exec: { command: args } }),
+  net: () => { throw new Error('net actions not implemented yet'); },
+};
+
+const probe = {
+  ...action,
+  delay: 'initialDelaySeconds',
+  timeout: 'timeoutSeconds',
+  interval: 'periodSeconds',
+  min_count_success: 'successThreshold',
+  min_count_failure: 'failureThreshold',
+};
+
+const portRe = /(?:(tcp|udp):\/\/)?(?:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}):)?(?:(\d{1,5}):)?(\d{1,5})/;
+
+function ports(pp) {
+  function parseContainerPort(p) {
+    let spec = p;
+    let name;
+    if (typeof p === 'object') {
+      for (name of Object.keys(p)) {
+        spec = p[name];
+        break;
+      }
+    } else {
+      spec = String(p);
+    }
+    const [/* scheme */, protocol, hostIP, hostPort, containerPort] = spec.match(portRe);
+    const port = {
+      name,
+      protocol: protocol && protocol.toUpperCase(),
+      hostIP,
+      hostPort,
+      containerPort,
+    };
+    Object.keys(port).forEach(k => port[k] === undefined && delete port[k]);
+    return port;
+  }
+  return { ports: pp.map(parseContainerPort) };
+}
+
+/* eslint-disable quote-props */
+const volumeMount = {
+  mount: 'mountPath',
+  store: 'name',
+  propagation: valueMap('mountPropagation', {
+    'host-to-container': 'HostToContainer',
+    'bidirectional': 'Bidirectional',
+  }),
+};
+
+/* eslint-disable quote-props */
+const containerSpec = {
+  name: 'name',
+  command: 'command',
+  args: 'args',
+  env: envVars,
+  image: 'image',
+  pull: valueMap('imagePullPolicy', {
+    'always': 'Always',
+    'never': 'Never',
+    'if-not-present': 'IfNotPresent',
+  }),
+  on_start: thread(action, 'lifecycle.postStart'),
+  pre_stop: thread(action, 'lifecycle.preStop'),
+  cpu: resource('cpu'),
+  mem: resource('memory'),
+  cap_add: 'securityContext.capabilities.add',
+  cap_drop: 'securityContext.capabilities.drop',
+  privileged: 'securityContext.privileged',
+  allow_escalation: 'securityContext.allowPrivilegeEscalation',
+  rw: thread(v => !v, 'securityContext.readOnlyRootFilesystem'),
+  ro: 'securityContext.readOnlyRootFilesystem',
+  force_non_root: 'securityContext.runAsNonRoot',
+  uid: 'securityContext.runAsUser',
+  selinux: 'securityContext.seLinuxOptions',
+  liveness_probe: thread(probe, 'livenessProbe'),
+  readiness_probe: thread(probe, 'readinessProbe'),
+  expose: ports,
+  stdin: 'stdin',
+  stdin_once: 'stdinOnce',
+  tty: 'tty',
+  wd: 'workingDir',
+  termination_message_path: 'terminationMessagePath',
+  terminal_message_policy: valueMap('terminationMessagePolicy', {
+    file: 'File',
+    'fallback-to-logs-on-error': 'FallbackToLogsOnError',
+  }),
+  volume: thread([volumeMount], 'volumeMounts'),
+};
+
+/* eslint-disable object-shorthand */
+const podSpec = {
+  ...objectMeta,
+  volumes: volumes,
+  affinity: affinities,
+  node: 'spec.nodeName',
+  containers: thread([containerSpec], 'spec.containers'),
+  init_containers: thread([containerSpec], 'spec.initContainers'),
+  dns_policy: valueMap('spec.dnsPolicy', {
+    'cluster-first': 'ClusterFirst',
+    'cluster-first-with-host-net': 'ClusterFirstWithHostNet',
+    'default': 'Default',
+  }),
+  host_aliases: hostAliases,
+  host_mode: hostMode,
+  hostname: hostName,
+  registry_secrets: thread([name => ({ name })], 'spec.imagePullSecrets'),
+  restart_policy: valueMap('spec.restartPolicy', {
+    'always': 'Always',
+    'on-failure': 'OnFailure',
+    'never': 'Never',
+  }),
+  scheduler_name: 'spec.schedulerName',
+  account: account,
+  tolerations: tolerations,
+  termination_grade_period: 'spec.terminationGradePeriodSeconds',
+  active_deadline: 'spec.activeDeadlineSeconds',
+  priority: priority,
+  fs_gid: 'spec.securityContext.fsGroup',
+  gids: 'spec.securityContext.supplementalGroups',
+};
+
+const workloadSpec = {
+  ...objectMeta,
+};
+
+function sessionAffinity(value) {
+  switch (typeof value) {
+  case 'boolean':
+    return { sessionAffinity: 'ClientIP' };
+  case 'number':
+    return {
+      sessionAffinity: 'ClientIP',
+      sessionAffinityConfig: {
+        clientIP: {
+          timeoutSeconds: value,
+        },
+      },
+    };
+  default:
+    throw new Error(`service stickiness of type ${typeof value} not supported`);
+  }
+}
+
+const serviceSpec = {
+  ...objectMeta,
+  cname: 'spec.externalName',
+  type: valueMap('spec.type', {
+    'cluster-ip': 'ClusterIP',
+    'load-balancer': 'LoadBalancer',
+    'node-port': 'NodePort',
+  }),
+  selector: 'spec.selector',
+  external_ips: 'externalIPs',
+  // port, node_port, ports -> TODO
+  cluster_ip: 'clusterIP',
+  unread_endpoints: 'publishNotReadyAddresses',
+  route_policy: valueMap('externalTrafficPolicy', {
+    'node-local': 'Node',
+    'cluster-wide': 'Cluster',
+  }),
+  stickiness: sessionAffinity,
+  lb_ip: 'loadBalancerIP',
+  lb_client_ips: 'loadBalancerSourceRanges',
+  healthcheck_port: 'healthCheckNodePort',
+};
+
+// TODO all the other ones.
+// TODO register new transforms (e.g., for custom resources).
+
+export default {
+  namespace: makeResource(core.v1.Namespace, objectMeta),
+  pod: makeResource(core.v1.Pod, podSpec),
+  deployment: makeResource(apps.v1.Deployment, workloadSpec),
+  service: makeResource(core.v1.Service, serviceSpec),
+};

--- a/src/short/transform.js
+++ b/src/short/transform.js
@@ -1,0 +1,74 @@
+import { patch } from '@jkcfg/mixins/src/mixins';
+
+// "Field transformer" functions take a _value_ and return an object
+// with _one or more fields_.
+//
+// In `transform`, the `spec` argument defines how to transform an
+// object with a map of field name to field transformer; the result of
+// applying a transformer is merged into the result.
+
+// relocate makes a field transformer function that will relocate a
+// value to the path given. The trivial case is a single element,
+// which effectively renames a field.
+function relocate(path) {
+  if (path === '') return v => v;
+
+  const elems = path.split('.').reverse();
+  return (v) => {
+    let obj = v;
+    for (const p of elems) {
+      obj = { [p]: obj };
+    }
+    return obj;
+  };
+}
+
+// transformer returns a field transformer given:
+//
+//  - a string, which relocates the field (possibly to a nested path);
+//  - a function, which is used as-is;
+//  - an object, which will be treated as the spec for transforming
+//    the (assumed object) value to get a new value.
+function transformer(field) {
+  switch (typeof field) {
+  case 'string': return relocate(field);
+  case 'function': return field;
+  case 'object': return v => transform(field, v);
+  default: return v => v;
+  }
+}
+
+// thread takes a varying number of individual field transformers, and
+// returns a function that will apply each transformer to the result
+// of the previous.
+function thread(...transformers) {
+  return initial => transformers.reduce((a, fn) => transformer(fn)(a), initial);
+}
+
+// valueMap creates a field transformer that maps the possible values
+// to other values, then relocates the field. This is useful, for
+// example, when the format has shorthands or aliases for enum values
+// (like service.type='cluster-ip').
+function valueMap(field, map) {
+  return thread(v => map[v], field);
+}
+
+// transform generates a new value from `v0` based on the
+// specification given. Each field in `spec` contains a field
+// transformer, which is used to generate a new field or fields to
+// merge into the result.
+function transform(spec, v0) {
+  let v1 = {};
+  for (const [field, value] of Object.entries(v0)) {
+    const tx = spec[field];
+    if (tx !== undefined) {
+      const fn = transformer(tx);
+      v1 = patch(v1, fn(value));
+    }
+  }
+  return v1;
+}
+
+export {
+  transform, relocate, valueMap, thread,
+};

--- a/src/short/transform.js
+++ b/src/short/transform.js
@@ -34,11 +34,15 @@ function transformer(field) {
   case 'string': return relocate(field);
   case 'function': return field;
   case 'object':
-    return (Array.isArray(field)) ?
-      v => v.map(transformer(field[0])):
-      v => transform(field, v);
-  default: return v => field;
+    return (Array.isArray(field)) ? thread(...field) : v => transform(field, v);
+  default: return () => field;
   }
+}
+
+// mapper lifts a value transformer into an array transformer
+function mapper(fn) {
+  const tx = transformer(fn);
+  return vals => Array.prototype.map.call(vals, tx);
 }
 
 // thread takes a varying number of individual field transformers, and
@@ -73,5 +77,5 @@ function transform(spec, v0) {
 }
 
 export {
-  transform, relocate, valueMap, thread,
+  transform, relocate, valueMap, thread, mapper,
 };

--- a/src/short/transform.js
+++ b/src/short/transform.js
@@ -52,6 +52,21 @@ function thread(...transformers) {
   return initial => transformers.reduce((a, fn) => transformer(fn)(a), initial);
 }
 
+// drop takes a transformation spec and returns another spec, with
+// each field transformed as beofre, then relocated _under_ path. This
+// is useful for reusing a spec in a different context; e.g., the
+// podSpec in a deployment template. In that case the fields are all
+// expected at the top level of the short form, but relocated _en
+// masse_ to `spec.template.spec`.
+function drop(path, spec) {
+  const reloc = relocate(path);
+  const newSpec = {};
+  for (const [field, tx] of Object.entries(spec)) {
+    newSpec[field] = thread(tx, reloc);
+  }
+  return newSpec;
+}
+
 // valueMap creates a field transformer that maps the possible values
 // to other values, then relocates the field. This is useful, for
 // example, when the format has shorthands or aliases for enum values
@@ -77,5 +92,5 @@ function transform(spec, v0) {
 }
 
 export {
-  transform, relocate, valueMap, thread, mapper,
+  transform, relocate, valueMap, thread, mapper, drop,
 };

--- a/src/short/transform.js
+++ b/src/short/transform.js
@@ -1,4 +1,4 @@
-import { patch } from '@jkcfg/mixins/src/mixins';
+import { patch } from '@jkcfg/std/merge';
 
 // "Field transformer" functions take a _value_ and return an object
 // with _one or more fields_.

--- a/src/short/transform.js
+++ b/src/short/transform.js
@@ -33,8 +33,11 @@ function transformer(field) {
   switch (typeof field) {
   case 'string': return relocate(field);
   case 'function': return field;
-  case 'object': return v => transform(field, v);
-  default: return v => v;
+  case 'object':
+    return (Array.isArray(field)) ?
+      v => v.map(transformer(field[0])):
+      v => transform(field, v);
+  default: return v => field;
   }
 }
 

--- a/tests/short.test.js
+++ b/tests/short.test.js
@@ -1,0 +1,40 @@
+import { long } from '../src/short';
+import { apps, core } from '../src/api';
+
+// Add to this as the spec gets more complete ...
+test('deployment', () => {
+  const dep = {
+    deployment: {
+      name: 'foo-dep',
+      namespace: 'foo-ns',
+      labels: { app: 'foo' },
+    }
+  };
+  expect(long(dep)).toEqual(new apps.v1.Deployment('foo-dep', {
+    metadata: {
+      namespace: 'foo-ns',
+      labels: { app: 'foo' },
+    },
+  }));
+});
+
+test('service', () => {
+  const svc = {
+    service: {
+      name: 'bar-svc',
+      namespace: 'bar-ns',
+      type: 'node-port',
+      selector: { app: 'bar' },
+    }
+  };
+  expect(long(svc)).toEqual(new core.v1.Service('bar-svc', {
+    metadata: {
+      namespace: 'bar-ns',
+      name: 'bar-svc',
+    },
+    spec: {
+      type: 'NodePort',
+      selector: { app: 'bar' }
+    }
+  }));
+});

--- a/tests/short_transforms.test.js
+++ b/tests/short_transforms.test.js
@@ -1,0 +1,97 @@
+import { relocate, valueMap, transform, thread } from '../src/short/transform';
+
+test.each([
+
+  {path: '', result: 'value'},
+  {path: 'foo', result: { foo: 'value' } },
+  {path: 'foo.bar.baz', result: { foo: { bar: { baz: 'value' } } } },
+
+])('relocate', ({ path, result }) => {
+  const rel = relocate(path);
+  expect(rel('value')).toEqual(result);
+});
+
+test.each([
+
+  {field: 'foo', map: {value: 'eulav'}, result: { 'foo': 'eulav'}},
+
+])('valueMap', ({ field, map, result }) => {
+  const vmap = valueMap(field, map);
+  expect(vmap('value')).toEqual(result);
+});
+
+test('transform function', () => {
+  const fn = _ => ({ always: 'replaced' });
+  const spec = { top: fn };
+  const value = { top: { value: 'discarded' } };
+  expect(transform(spec, value)).toEqual(
+    { always: 'replaced' }
+  );
+});
+
+test('transform relocate', () => {
+  const spec = { top: 'to.the.bottom' };
+  const value = { top: 'value' };
+  expect(transform(spec, value)).toEqual(
+    { to: { the: { bottom: 'value' } } }
+  );
+});
+
+test('transform recurse', () => {
+  const spec = { top: { sub: 'renamed' } };
+  const value = { top: { sub: 'value' } };
+  expect(transform(spec, value)).toEqual(
+    { renamed: 'value' }
+  );
+});
+
+test('transform thread', () => {
+  const spec = {
+    field: thread(valueMap('other', { 'value': 'eulav' }),
+                  'nested.down.here')
+  };
+  const value = { field: 'value' };
+
+  expect(transform(spec, value)).toEqual(
+    {
+      nested: {
+        down: {
+          here: {
+            other: 'eulav',
+          }
+        }
+      }
+    }
+  );
+});
+
+test('transform all', () => {
+  const spec = {
+    version: 'apiVersion',
+    name: 'metadata.name',
+    labels: 'metadata.labels',
+    recreate: thread(v => (v) ? 'Recreate' : 'RollingUpdate', 'spec.strategy.type'),
+  };
+
+  const value = {
+    version: 'apps/v1',
+    name: 'foo-dep',
+    labels: { app: 'foo' },
+    recreate: false,
+  };
+
+  expect(transform(spec, value)).toEqual(
+    {
+      apiVersion: 'apps/v1',
+      spec: {
+        strategy: {
+          type: 'RollingUpdate',
+        }
+      },
+      metadata: {
+        name: 'foo-dep',
+        labels: { app: 'foo' },
+      },
+    }
+  );
+});


### PR DESCRIPTION
Inspired by https://docs.koki.io/short/, this implements a short
syntax for Kubernetes resources.

The implementation is via a "transformer spec" interpreter. I'm not
wedded to it, but it works well for the toy tests and examples so far.

Rough example of the short format:

```yaml
deployment:
  name: foo
  namespace: foo-ns
  labels: { app: foo }
  containers:
  - name: hello
    image: helloworld:v1
```
