### PR TITLE
Test that make dist passes CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ jobs:
     - name: unit tests
       script: make test
 
+    - name: dist
+      script: make dist
+
     - stage: Deploy
       script:
         # build and publish

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ src/shapes.ts: gen
 dist: src/api.ts src/shapes.ts
 	npx tsc
 	npx tsc -d --emitDeclarationOnly --allowJs false
-	cp README.md LICENSE package.json .npmrc @jkcfg/kubernetes
+	cp README.md LICENSE package.json @jkcfg/kubernetes
 
 clean:
 	rm -rf @jkcfg


### PR DESCRIPTION
We had a regression where `make dist` was failing on master. Make sure it doesn't happen again.