### PR TITLE
ImageReference: Add an image getter

### DIFF
--- a/src/image-reference.ts
+++ b/src/image-reference.ts
@@ -188,6 +188,11 @@ class ImageReference {
         }
     }
 
+    get image(): string {
+        const components = this.path.split('/');
+        return components[components.length - 1];
+    }
+
     toString(): string {
         let s = '';
 

--- a/tests/image-reference.test.js
+++ b/tests/image-reference.test.js
@@ -43,7 +43,7 @@ import { ImageReference } from '../src/image-reference';
   ['docker.io/library/ubuntu:18.04'],
   ['docker.io/library/ubuntu:18.04@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'],
 ].forEach(([input]) => {
-  test(input, () => {
+  test(`toString: ${input}`, () => {
     const ref = ImageReference.fromString(input);
     expect(ref.toString()).toEqual(input);
   });

--- a/tests/image-reference.test.js
+++ b/tests/image-reference.test.js
@@ -48,3 +48,14 @@ import { ImageReference } from '../src/image-reference';
     expect(ref.toString()).toEqual(input);
   });
 });
+
+[
+  ['ubuntu', { output: 'ubuntu' }],
+  ['ubuntu:18.04', { output: 'ubuntu' }],
+  ['docker.io/library/ubuntu:18.04', { output: 'ubuntu' }],
+].forEach(([input, expected]) => {
+  test(`image: ${input}`, () => {
+    const ref = ImageReference.fromString(input);
+    expect(ref.image).toEqual(expected.output);
+  });
+});


### PR DESCRIPTION
It can be useful to extract the last part of the path when manipulating docker image references, for instance to replace the regitsry.
