### PR TITLE
Use @jkcfg/std/merge rather than mixins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,10 +24,10 @@
         "js-tokens": "^4.0.0"
       }
     },
-    "@jkcfg/mixins": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@jkcfg/mixins/-/mixins-0.1.2.tgz",
-      "integrity": "sha512-CFbvPk30gJzv8ddY+jdXxP9JLmFCNYP9aTzFg43d+xAJOPrUJpPRkwkvQcd2j78yi4j7CxPMJw2BvlxcJsp2jw=="
+    "@jkcfg/std": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@jkcfg/std/-/std-0.2.6.tgz",
+      "integrity": "sha512-CTN6zvYmUJ9sFVv+Bv+VJqEx9ILl+DAT6Db4jkhE4tcOdw2uUnRlFSt96ucnJ/9TD4OjjVI9eg6DYJkRNaClbA=="
     },
     "abab": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/jkcfg/kubernetes/issues"
   },
   "dependencies": {
-    "@jkcfg/mixins": "^0.1.2",
+    "@jkcfg/std": "^0.2.6",
     "handlebars": "^4.1.1"
   },
   "description": "jk Kubernetes library",

--- a/src/chart/values.js
+++ b/src/chart/values.js
@@ -1,4 +1,4 @@
-import { patch } from '@jkcfg/mixins/src/mixins';
+import { patch } from '@jkcfg/std/merge';
 
 // Given a means of getting parameters, and a specification of the
 // Values (including their defaults), compile a struct of values for

--- a/src/overlay/transforms.js
+++ b/src/overlay/transforms.js
@@ -1,4 +1,4 @@
-import { patch, patches } from '@jkcfg/mixins/src/mixins';
+import { patch, mix } from '@jkcfg/std/merge';
 import { iterateContainers } from '../resources';
 
 // resourceMatch returns a predicate which gives true if the given
@@ -43,7 +43,7 @@ function commonMetadata({ commonLabels = null, commonAnnotations = null, namespa
   if (namespace !== null) {
     metaPatches.push({ metadata: { namespace } });
   }
-  return patches(...metaPatches);
+  return r => mix(r, ...metaPatches);
 }
 
 // rewriteImageRefs applies the given rewrite function to each image


### PR DESCRIPTION
We deprecated mixins in favour of having the merge primitives in the
std lib.

The dependency in the package.json anticipates the next release of jk
(and publication of the NPM package) which will include `merge` as an
importable module.

 - [x] why is jest not attempting to transform the ES6 files in @jkcfg/std? (A: because my local setup, somehow)