### PR TITLE
Fix a fudge in the chart templates example

### DIFF
--- a/examples/chart/index2.js
+++ b/examples/chart/index2.js
@@ -1,9 +1,8 @@
 // Example of a Helm chart analogue, using handlebars
 
-import { chart, loadModuleTemplates } from '@jkcfg/kubernetes/chart';
-import { writeYAMLStream } from '@jkcfg/kubernetes/write';
+import { generateChart, loadModuleTemplates } from '@jkcfg/kubernetes/chart';
 import * as resource from '@jkcfg/std/resource';
-import std from '@jkcfg/std';
+import * as param from '@jkcfg/std/param';
 import handlebars from 'handlebars/lib/handlebars';
 
 const defaults = {
@@ -17,4 +16,4 @@ const defaults = {
 
 const templates = loadModuleTemplates(handlebars.compile, resource);
 
-chart(templates, defaults, std.param).then(val => std.log(val, { format: std.Format.YAMLStream }));
+export default generateChart(templates, defaults, param);

--- a/examples/chart/templates/deployment.yaml
+++ b/examples/chart/templates/deployment.yaml
@@ -1,6 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
-meta:
+metadata:
   name: '{{values.name}}-dep'
 spec:
   template:

--- a/examples/chart/templates/service.yaml
+++ b/examples/chart/templates/service.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Service
-meta:
+metadata:
   name: '{{values.name}}-svc'
 spec:
   selector:

--- a/src/chart/template.js
+++ b/src/chart/template.js
@@ -8,7 +8,7 @@ const loadTemplate = ({ readString, parse, compile }) => async function load(pat
 };
 
 function flatMap(fn, array) {
-  return Array.prototype.concat.call(Array.prototype.map.call(array, fn));
+  return [].concat(...array.map(fn));
 }
 
 // { readString, compile, dir } -> values -> Promise [string]

--- a/tests/chart_templates.test.js
+++ b/tests/chart_templates.test.js
@@ -35,7 +35,7 @@ const readString = (path) => {
 };
 
 test('load a dir of templates', () => {
-  const templates = loadDir({ dir, readString, compile, parse: s => s });
+  const templates = loadDir({ dir, readString, compile, parse: s => [s] });
   const out = templates({ variable: 'handlebars' });
   expect.assertions(2);
   return out.then(([foo, bar]) => {


### PR DESCRIPTION
The implementation of `flatMap` in template.js was off, and I had
unthinkingly compensated for that by adjusting the test.

This corrects the implementation and test, and ports the chart
template example to work with `jk generate`.