### PR TITLE
Port to jk 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,9 @@
       }
     },
     "@jkcfg/std": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@jkcfg/std/-/std-0.2.6.tgz",
-      "integrity": "sha512-CTN6zvYmUJ9sFVv+Bv+VJqEx9ILl+DAT6Db4jkhE4tcOdw2uUnRlFSt96ucnJ/9TD4OjjVI9eg6DYJkRNaClbA=="
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@jkcfg/std/-/std-0.2.10.tgz",
+      "integrity": "sha512-HB38+9XYOVeVfLheBHFrLcM/lpGRfz4aikmP+f+PSyHNlwW/1VZ0/Z9U5qp7ONUCqM27zX1++gWKdWwA6kJruA=="
     },
     "abab": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1674,6 +1674,7 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
       "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+      "dev": true,
       "optional": true
     },
     "component-emitter": {
@@ -3156,6 +3157,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
       "integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
+      "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -4509,7 +4511,8 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "mixin-deep": {
       "version": "1.3.1",
@@ -4608,7 +4611,8 @@
     "neo-async": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
-      "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA=="
+      "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+      "dev": true
     },
     "nice-try": {
       "version": "1.0.5",
@@ -4816,6 +4820,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
@@ -4824,7 +4829,8 @@
         "wordwrap": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
         }
       }
     },
@@ -6021,7 +6027,8 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.2",
@@ -6490,6 +6497,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.2.tgz",
       "integrity": "sha512-imog1WIsi9Yb56yRt5TfYVxGmnWs3WSGU73ieSOlMVFwhJCA9W8fqFFMMj4kgDqiS/80LGdsYnWL7O9UcjEBlg==",
+      "dev": true,
       "optional": true,
       "requires": {
         "commander": "~2.19.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/jkcfg/kubernetes/issues"
   },
   "dependencies": {
-    "@jkcfg/std": "^0.2.6"
+    "@jkcfg/std": "^0.2.10"
   },
   "description": "jk Kubernetes library",
   "devDependencies": {

--- a/src/chart/values.js
+++ b/src/chart/values.js
@@ -1,4 +1,4 @@
-import { patch } from '@jkcfg/std/merge';
+import { merge } from '@jkcfg/std/merge';
 
 // Given a means of getting parameters, and a specification of the
 // Values (including their defaults), compile a struct of values for
@@ -15,7 +15,7 @@ import { patch } from '@jkcfg/std/merge';
 const values = (param, opts = {}) => function compile(defaults) {
   const { prefix = 'values' } = opts;
   const commandLine = param.Object(prefix, {});
-  return patch(defaults, commandLine);
+  return merge(defaults, commandLine);
 };
 
 export { values };

--- a/src/chart/values.js
+++ b/src/chart/values.js
@@ -3,7 +3,7 @@ import { patch } from '@jkcfg/std/merge';
 // Given a means of getting parameters, and a specification of the
 // Values (including their defaults), compile a struct of values for
 // instantiating a chart. To discriminate the values from other
-// parameters, an option is the prfix; by default, we expect the
+// parameters, an option is the prefix; by default, we expect the
 // command-line values to be passed as e.g., `-p values.image.tag=v1`,
 // and any file(s) (e.g., passed as `-f value.json`) to be of the form
 //

--- a/src/short/transform.js
+++ b/src/short/transform.js
@@ -1,4 +1,4 @@
-import { patch } from '@jkcfg/std/merge';
+import { merge } from '@jkcfg/std/merge';
 
 // "Field transformer" functions take a _value_ and return an object
 // with _one or more fields_.
@@ -85,7 +85,7 @@ function transform(spec, v0) {
     const tx = spec[field];
     if (tx !== undefined) {
       const fn = transformer(tx);
-      v1 = patch(v1, fn(value));
+      v1 = merge(v1, fn(value));
     }
   }
   return v1;

--- a/src/transform/index.js
+++ b/src/transform/index.js
@@ -1,5 +1,30 @@
-import { patch, mix } from '@jkcfg/std/merge';
+import { merge } from '@jkcfg/std/merge';
 import { iterateContainers } from '../resources';
+
+// Interpret a series of transformations expressed either as object
+// patches (as in the argument to `patch` in this module), or
+// functions. Usually the first argument will be an object,
+// representing an initial value, but it can be a function (that will
+// be given an empty object as its argument).
+function mix(...transforms) {
+  let r = {};
+
+  for (const transform of transforms) {
+    switch (typeof transform) {
+    case 'object':
+      r = merge(r, transform);
+      break;
+    case 'function':
+      r = transform(r);
+      break;
+    default:
+      throw new TypeError('only objects and functions allowed as arguments');
+    }
+  }
+
+  return r;
+}
+
 
 // resourceMatch returns a predicate which gives true if the given
 // object represents the same resource as `template`, false otherwise.
@@ -23,7 +48,7 @@ function resourceMatch(target) {
 // untouched.
 function patchResource(p) {
   const match = resourceMatch(p);
-  return v => (match(v) ? patch(v, p) : v);
+  return v => (match(v) ? merge(v, p) : v);
 }
 
 // commonMetadata returns a tranformation that will indiscriminately

--- a/tests/overlay.test.js
+++ b/tests/overlay.test.js
@@ -1,7 +1,7 @@
 import { compile } from '../src/overlay/compile';
 import { fs, Encoding } from './mock';
 import { core } from '../src/api';
-import { merge } from '@jkcfg/std/merge';
+import { merge, deepWithKey } from '@jkcfg/std/merge';
 
 test('trivial overlay: no bases, resources, patches', () => {
   const { read } = fs({}, {});
@@ -82,13 +82,21 @@ test('user-provided transformation', () => {
   const insertSidecar = (v) => {
     if (v.kind === 'Deployment') {
       return merge(v, {
-        'spec+': {
-          'template+': {
-            'spec+': {
-              'containers+': [{ name: 'sidecar', image: 'side:v1' }],
+        spec: {
+          template: {
+            spec: {
+              containers: [{ name: 'sidecar', image: 'side:v1' }],
             },
           },
         },
+      }, {
+        spec: {
+          template: {
+            spec: {
+              containers: deepWithKey('name'),
+            }
+          }
+        }
       });
     }
     return v;


### PR DESCRIPTION
jk 0.3.0 has a few breaking changes in `merge.js`:

- The new merge function replaces patch().
- there's a new way to express merging strategies, replacing the "patches" with + at the end of keys.

The tests pass locally when copying `jk` 0.3.0 `merge.js` in the `node_modules/@jkcfg/std` directory.