### PR TITLE
Validate schemas

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,8 +6,7 @@
       2,
       {
         "ignore": [
-          "^std$",
-          "^@jkcfg/std$",
+          "^@jkcfg/std($|/)",
           "/?(api|shapes)$",
         ]
       }

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "schemas"]
+	path = schemas
+	url = https://github.com/instrumenta/kubernetes-json-schema

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dist clean gen test
+.PHONY: all dist clean gen test copy-schemas
 
 all: gen
 
@@ -8,10 +8,11 @@ gen:
 src/api.ts: gen
 src/shapes.ts: gen
 
-dist: src/api.ts src/shapes.ts
+dist: src/api.ts src/shapes.ts copy-schemas
 	npx tsc
 	npx tsc -d --emitDeclarationOnly --allowJs false
 	cp README.md LICENSE package.json @jkcfg/kubernetes
+	cp -R src/schemas @jkcfg/kubernetes/
 
 clean:
 	rm -rf @jkcfg
@@ -20,3 +21,10 @@ clean:
 test: gen
 	npm test
 	npm run lint
+
+copy-schemas:
+	git submodule update -- ./schemas
+	mkdir -p build/schemas
+	for d in schemas/*-local; do   \
+		cp -R "$$d" src/schemas/; \
+	done

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,9 @@
       }
     },
     "@jkcfg/std": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@jkcfg/std/-/std-0.3.0.tgz",
-      "integrity": "sha512-yjPT76/9KJjv2/WFgl8oZiPsku9y6qwKYP8INJygLQMMouFMd+IC3saywRA8DDbFblZDd27nourBlw5Wecz11g=="
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jkcfg/std/-/std-0.3.2.tgz",
+      "integrity": "sha512-bdJs88KZE2GSlkY2/eVn7fUi9o022urWWUqw7JAyMZNyQaOhkSAzn2TfU/Bp63P0pwbMPqEbmcrTq6oSMOlmqQ=="
     },
     "abab": {
       "version": "2.0.0",
@@ -2535,8 +2535,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2557,14 +2556,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2579,20 +2576,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2709,8 +2703,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2722,7 +2715,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2737,7 +2729,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2745,14 +2736,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2771,7 +2760,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2852,8 +2840,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2865,7 +2852,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2951,8 +2937,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2988,7 +2973,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3008,7 +2992,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3052,14 +3035,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/jkcfg/kubernetes/issues"
   },
   "dependencies": {
-    "@jkcfg/std": "^0.3.0"
+    "@jkcfg/std": "^0.3.2"
   },
   "description": "jk Kubernetes library",
   "devDependencies": {

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,0 +1,17 @@
+/**
+ * The schema module gives access to Kubernetes JSON Schema definitions.
+ */
+
+import { withModuleRef } from '@jkcfg/std/resource';
+import { validateWithResource } from '@jkcfg/std/schema';
+
+function resourcePath(k8sVersion, apiVersion, kind) {
+  const groupVersion = apiVersion.split('/');
+  groupVersion.unshift(kind);
+  return `schemas/${k8sVersion}-local/${groupVersion.join('-').toLowerCase()}.json`;
+}
+
+export function validateSchema(k8sVersion, value) {
+  const path = resourcePath(k8sVersion, value.apiVersion, value.kind);
+  return withModuleRef(ref => validateWithResource(value, path, ref));
+}

--- a/src/validate.js
+++ b/src/validate.js
@@ -1,0 +1,13 @@
+/**
+ * The validate module exports a function for use with `jk validate`
+ */
+
+import * as param from '@jkcfg/std/param';
+import { validateSchema } from './schema';
+
+const defaultK8sVersion = 'v1.16.0';
+
+export default function validate(value) {
+  const k8sVersion = param.String('k8s-version', defaultK8sVersion);
+  return validateSchema(k8sVersion, value);
+}


### PR DESCRIPTION
 - vendors Kubernetes JSON Schema files from
   https://github.com/instrumenta/kubernetes-json-schema using `git
   submodule`

 - provides a wrapper for using those schemas for validation

 - provides a validation function as a default export, for use with
   `jk validate`

This is good enough to use with `jk validate`, e.g.,

    jk validate -m @jkcfg/kubernetes/validate ./config/*.yaml
