### PR TITLE
build: Use git submodule update --init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test: gen
 	npm run lint
 
 copy-schemas:
-	git submodule update -- ./schemas
+	git submodule update --init -- ./schemas
 	mkdir -p build/schemas
 	for d in schemas/*-local; do   \
 		cp -R "$$d" src/schemas/; \


### PR DESCRIPTION
$ make dist
GO111MODULE=on go run ./cmd/apigen/ cmd/apigen/specs/swagger-v1.13.0.json cmd/apigen/templates ./src/
git submodule update -- ./schemas
Submodule path 'schemas' not initialized
Maybe you want to use 'update --init'?
mkdir -p build/schemas
for d in schemas/*-local; do   \
	cp -R "$d" src/schemas/; \
done
cp: cannot stat 'schemas/*-local': No such file or directory
Makefile:30: recipe for target 'copy-schemas' failed
make: *** [copy-schemas] Error 1

Fixes: #54