### PR TITLE
Let people get all the files in one dir

### DIFF
--- a/src/generate.js
+++ b/src/generate.js
@@ -1,12 +1,12 @@
 // Given an array (or a promise of an array) of Kubernetes resources,
 // return a list of values suitable for use with `jk generate`
 async function valuesForGenerate(resources, opts = {}) {
-  const { prefix = '' } = opts;
+  const { prefix = '', namespaceDirs = true } = opts;
   const all = await Promise.resolve(resources);
   return all.map((r) => {
     const filename = `${r.metadata.name}-${r.kind.toLowerCase()}.yaml`;
     let path = filename;
-    if (r.metadata.namespace) {
+    if (namespaceDirs && r.metadata.namespace) {
       path = `${r.metadata.namespace}/${filename}`;
     }
     if (prefix !== '') {

--- a/tests/generate.test.js
+++ b/tests/generate.test.js
@@ -28,3 +28,31 @@ test('valuesForGenerate', () => {
     }));
   });
 });
+
+test('valuesForGenerate (flatten)', () => {
+  const output = {};
+  const write = ({ file, value }) => {
+    output[file] = value;
+  };
+
+  // I'm mostly checking whether it gets the paths and so on correct.
+  const resources = [
+    new core.v1.Namespace('foo', {}),
+    new apps.v1.Deployment('bar', {
+      metadata: { namespace: 'foo' },
+    }),
+    new core.v1.Service('foosrv', {
+      metadata: { namespace: 'foo' },
+    }),
+  ];
+
+  expect.assertions(1);
+  return valuesForGenerate(resources, { namespaceDirs: false }).then(files => {
+    files.forEach(write);
+    expect(output).toEqual(expect.objectContaining({
+      'foo-namespace.yaml': expect.any(core.v1.Namespace),
+      'bar-deployment.yaml': expect.any(apps.v1.Deployment),
+      'foosrv-service.yaml': expect.any(core.v1.Service),
+    }));
+  });
+});


### PR DESCRIPTION
`valuesForGenerate` will put each file in a directory named for its
namespace, if it has one. But sometimes you just want them all in the
same dir (and collisions be damned).