### PR TITLE
Use only the first segment of the schema group

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -1,17 +1,25 @@
 /**
- * The schema module gives access to Kubernetes JSON Schema definitions.
+ * The schema module calculates access to Kubernetes JSON Schema
+ * definitions. It's kept separate from validate.js so that only one
+ * is tied to the jk runtime (by using resources).
  */
 
-import { withModuleRef } from '@jkcfg/std/resource';
-import { validateWithResource } from '@jkcfg/std/schema';
-
-function resourcePath(k8sVersion, apiVersion, kind) {
+// schemaPath returns the path to the schema for a given Kubernetes
+// object, starting from wherever schemas are kept.
+export function schemaPath(k8sVersion, apiVersion, kind) {
+  // this reproduces the logic from the tool that generates the
+  // schemas:
+  //
+  //     https://github.com/instrumenta/openapi2jsonschema/blob/master/openapi2jsonschema/command.py#L132
+  //
+  // and ff.
   const groupVersion = apiVersion.split('/');
-  groupVersion.unshift(kind);
-  return `schemas/${k8sVersion}-local/${groupVersion.join('-').toLowerCase()}.json`;
-}
-
-export function validateSchema(k8sVersion, value) {
-  const path = resourcePath(k8sVersion, value.apiVersion, value.kind);
-  return withModuleRef(ref => validateWithResource(value, path, ref));
+  // 'apps/v1' vs 'v1'
+  if (groupVersion.length > 1) {
+    // 'apiextensions.k8s.io' vs 'apps'
+    const [group] = groupVersion[0].split('.');
+    groupVersion[0] = group;
+  }
+  const kindGroupVersion = [kind, ...groupVersion];
+  return `${k8sVersion}-local/${kindGroupVersion.join('-').toLowerCase()}.json`;
 }

--- a/src/validate.js
+++ b/src/validate.js
@@ -1,11 +1,19 @@
 /**
- * The validate module exports a function for use with `jk validate`
+ * The validate module exports a default value for use with `jk
+ * validate`.
  */
 
 import * as param from '@jkcfg/std/param';
-import { validateSchema } from './schema';
+import { withModuleRef } from '@jkcfg/std/resource';
+import { validateWithResource } from '@jkcfg/std/schema';
+import { schemaPath } from './schema';
 
 const defaultK8sVersion = 'v1.16.0';
+
+export function validateSchema(k8sVersion, value) {
+  const path = schemaPath(k8sVersion, value.apiVersion, value.kind);
+  return withModuleRef(ref => validateWithResource(value, `schemas/${path}`, ref));
+}
 
 export default function validate(value) {
   const k8sVersion = param.String('k8s-version', defaultK8sVersion);

--- a/tests/schema.test.js
+++ b/tests/schema.test.js
@@ -1,0 +1,15 @@
+import { schemaPath } from '../src/schema';
+
+const k8s = 'v1.16.0'; // just for the sake of supplying something
+
+test('service v1', () => {
+  expect(schemaPath(k8s, 'v1', 'Service')).toEqual(`${k8s}-local/service-v1.json`);
+});
+
+test('deployment apps/v1', () => {
+  expect(schemaPath(k8s, 'apps/v1', 'Deployment')).toEqual(`${k8s}-local/deployment-apps-v1.json`);
+});
+
+test('customresourcedefinition apiextensions.k8s.io/v1beta1', () => {
+  expect(schemaPath(k8s, 'apiextensions.k8s.io/v1beta1', 'CustomResourceDefinition')).toEqual(`${k8s}-local/customresourcedefinition-apiextensions-v1beta1.json`);
+});


### PR DESCRIPTION
The tool that generates the schemas in use here,
https://github.com/instrumenta/openapi2jsonschema, shortens group
names for Kubernetes definitions to just the first segment -- e.g.,
`apiextensions.k8s.io` gets the group `apiextensions`. The group is
then used to name the schema file generated.

This commit reproduces that logic in the schema.js, so that it can
find the right file for resources that have a dotted name as above.

Fixes #69.