### PR TITLE
Avoid regenerating the schemas directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SCHEMA_ZIP:=build/${KUBE_SCHEMA_ORG}-${KUBE_SCHEMA_REPO}-${KUBE_SCHEMA_SHA1}.zip
 # the next one is a consequence of how the zip file is made: the files
 # will be in a directory named for the repo and commit hash.
 SCHEMA_DIR:=build/raw/${KUBE_SCHEMA_REPO}-${KUBE_SCHEMA_SHA1}
+COPIED_MARK:=build/.copied.${KUBE_SCHEMA_SHA1}
 
 .PHONY: all dist clean gen test copy-schemas
 
@@ -16,7 +17,7 @@ gen:
 src/api.ts: gen
 src/shapes.ts: gen
 
-dist: src/api.ts src/shapes.ts copy-schemas
+dist: src/api.ts src/shapes.ts ${COPIED_MARK}
 	npx tsc
 	npx tsc -d --emitDeclarationOnly --allowJs false
 	cp README.md LICENSE package.json @jkcfg/kubernetes
@@ -31,9 +32,10 @@ test: gen
 	npm test
 	npm run lint
 
-copy-schemas: ${SCHEMA_DIR}
+${COPIED_MARK}: ${SCHEMA_DIR}
 	rm -rf ./build/schemas
 	GO111MODULE=on go run ./cmd/dedup/ ${SCHEMA_DIR} ./build/schemas
+	touch ${COPIED_MARK}
 
 build-image: dist
 	mkdir -p build/image


### PR DESCRIPTION
It's quite expensive to wipe the build/schemas directory and do the
de-duplicating again, and it will seldom change. So: use a sentinel
file, named for the particular revision of schemas used.