### PR TITLE
Put module in /jk/modules/ in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
 FROM scratch
-COPY @jkcfg/kubernetes /@jkcfg/kubernetes/
+COPY @jkcfg/kubernetes /jk/modules/@jkcfg/kubernetes/


### PR DESCRIPTION
The merged version of image support expects modules in /jk/modules/
within an image.