### PR TITLE
Use yannh/kubernetes-json-schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,6 @@
-KUBE_SCHEMA_ORG:=jkcfg
-KUBE_SCHEMA_REPO:=kubernetes-schema
-KUBE_SCHEMA_SHA1:=83d92a798500efd744a576df994196e75f3133dd
-SCHEMA_ZIP:=build/${KUBE_SCHEMA_ORG}-${KUBE_SCHEMA_REPO}-${KUBE_SCHEMA_SHA1}.zip
-# the next one is a consequence of how the zip file is made: the files
-# will be in a directory named for the repo and commit hash.
+KUBE_SCHEMA_ORG:=yannh
+KUBE_SCHEMA_REPO:=kubernetes-json-schema
+KUBE_SCHEMA_SHA1:=master
 SCHEMA_DIR:=build/raw/${KUBE_SCHEMA_REPO}-${KUBE_SCHEMA_SHA1}
 COPIED_MARK:=build/.copied.${KUBE_SCHEMA_SHA1}
 
@@ -42,9 +39,10 @@ build-image: dist
 	cp -R @jkcfg build/image/
 	docker build -t jkcfg/kubernetes -f Dockerfile build/image
 
-${SCHEMA_ZIP}:
+${SCHEMA_DIR}:
 	mkdir build
-	curl -L -o "$@" "https://github.com/${KUBE_SCHEMA_ORG}/${KUBE_SCHEMA_REPO}/archive/${KUBE_SCHEMA_SHA1}.zip"
-
-${SCHEMA_DIR}: ${SCHEMA_ZIP}
-	unzip -q ${SCHEMA_ZIP} -d build/raw/ "${KUBE_SCHEMA_REPO}-${KUBE_SCHEMA_SHA1}/*-local/*.json"
+	git clone --depth 1 --no-checkout "https://github.com/${KUBE_SCHEMA_ORG}/${KUBE_SCHEMA_REPO}" ${SCHEMA_DIR}
+	cd ${SCHEMA_DIR} && \
+	git sparse-checkout init --cone && \
+	git ls-tree -d -r HEAD --name-only | grep -E "v.*-local" | xargs git sparse-checkout add && \
+  git read-tree -mu HEAD

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 KUBE_SCHEMA_ORG:=yannh
 KUBE_SCHEMA_REPO:=kubernetes-json-schema
-KUBE_SCHEMA_SHA1:=master
+KUBE_SCHEMA_SHA1:=23cab9da14079ad764032a4b1c6efaef6739d24b
 SCHEMA_DIR:=build/raw/${KUBE_SCHEMA_REPO}-${KUBE_SCHEMA_SHA1}
 COPIED_MARK:=build/.copied.${KUBE_SCHEMA_SHA1}
 
@@ -40,7 +40,7 @@ build-image: dist
 	docker build -t jkcfg/kubernetes -f Dockerfile build/image
 
 ${SCHEMA_DIR}:
-	mkdir build
+	mkdir -p build
 	git clone --depth 1 --no-checkout "https://github.com/${KUBE_SCHEMA_ORG}/${KUBE_SCHEMA_REPO}" ${SCHEMA_DIR}
 	cd ${SCHEMA_DIR} && \
 	git sparse-checkout init --cone && \


### PR DESCRIPTION
Use [yannh/kubernetes-json-schema](https://github.com/yannh/kubernetes-json-schema/) instead of [jkcfg/kubernetes-schema](https://github.com/jkcfg/kubernetes-schema)

**Why ?**

`yannh/kubernetes-json-schema` seems to be a regularly synced fork. See issue: https://github.com/instrumenta/kubernetes-json-schema/issues/26

**Changes**

1. Updated `Makefile` to use a sparse checkout of `v*-local` directories.
2. Removed `SCHEMA_ZIP` 
3. Use `master` of `yannh/kubernetes-json-schema`